### PR TITLE
build: fix sub-crates import and update taceo versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 ark-algebra-test-templates = "0.5"
-ark-babyjubjub = { package = "taceo-ark-babyjubjub", path = "ark-babyjubjub", version = "0.5" }
 ark-bn254 = "0.5"
 ark-curve-constraint-tests = "0.5"
 ark-ec = { version = "0.5", default-features = false }
@@ -22,7 +21,7 @@ ark-ff = { version = "0.5", default-features = false }
 ark-groth16 = { version = "0.5", default-features = false }
 ark-r1cs-std = { version = "0.5", default-features = false }
 ark-relations = { version = "0.5", default-features = false }
-ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.4", default-features = false, features = [
+ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.5", default-features = false, features = [
   "babyjubjub"
 ] }
 ark-serialize = { version = "0.5", default-features = false }
@@ -31,11 +30,13 @@ blake3 = "1"
 eyre = "0.6"
 num-bigint = "0.4"
 num-traits = "0.2"
-poseidon2 = { package = "taceo-poseidon2", path = "poseidon2", version = "0.2", default-features = false }
 rand = "0.8"
 serde = { version = "1" }
 thiserror = "2"
 zeroize = "1"
+
+[patch.crates-io]
+taceo-ark-babyjubjub = { path = "ark-babyjubjub" }
 
 # This profile can be used for CI in pull requests.
 [profile.ci-dev]

--- a/deny.toml
+++ b/deny.toml
@@ -23,13 +23,13 @@
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
 targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #"x86_64-unknown-linux-musl",
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+  # The triple can be any string, but only the target triples built in to
+  # rustc (as of 1.40) can be checked against actual config expressions
+  # "x86_64-unknown-linux-musl",
+  # You can also specify which target_features you promise are enabled for a
+  # particular target. target_features are currently not validated against
+  # the actual valid features supported by the target architecture.
+  # { triple = "wasm32-unknown-unknown", features = ["atomics"] },
 ]
 # When creating the dependency graph used as the source of truth when checks are
 # executed, this field can be used to prune crates from the graph, removing them
@@ -38,7 +38,7 @@ targets = [
 # they are connected to another crate in the graph that hasn't been pruned,
 # so it should be used with care. The identifiers are [Package ID Specifications]
 # (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
-#exclude = []
+# exclude = []
 # If true, metadata will be collected with `--all-features`. Note that this can't
 # be toggled off if true, if you want to conditionally enable `--all-features` it
 # is recommended to pass `--all-features` on the cmd line instead
@@ -48,7 +48,7 @@ all-features = false
 no-default-features = false
 # If set, these feature will be enabled when collecting metadata. If `--features`
 # is specified on the cmd line they will take precedence over this option.
-#features = []
+# features = []
 
 # The output table provides options for how/if diagnostics are outputted
 [output]
@@ -64,20 +64,21 @@ feature-depth = 1
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 # The path where the advisory databases are cloned/fetched into
-#db-path = "$CARGO_HOME/advisory-dbs"
+# db-path = "$CARGO_HOME/advisory-dbs"
 # The url(s) of the advisory databases to use
-#db-urls = ["https://github.com/rustsec/advisory-db"]
+# db-urls = ["https://github.com/rustsec/advisory-db"]
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    { id = "RUSTSEC-2024-0436", reason = "paste no longer maintained, dep of arkworks" },
-    { id = "RUSTSEC-2025-0055", reason = "tracing-subscriber, dep of arkworks, only for tests" },
+  { id = "RUSTSEC-2024-0436", reason = "paste no longer maintained, dep of arkworks" },
+  { id = "RUSTSEC-2025-0055", reason = "tracing-subscriber, dep of arkworks, only for tests" },
+  { id = "RUSTSEC-2026-0097", reason = "can't upgrade due to transative deps. Doesn't affect us because we don't enable the log feature" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
 # Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
 # See Git Authentication for more information about setting up git authentication.
-#git-fetch-with-cli = true
+# git-fetch-with-cli = true
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
@@ -95,28 +96,28 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], crate = "adler32" },
+  # Each entry is the crate and version constraint, and its specific allow
+  # list
+  # { allow = ["Zlib"], crate = "adler32" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the
 # licensing information
-#[[licenses.clarify]]
+# [[licenses.clarify]]
 # The package spec the clarification applies to
-#crate = "ring"
+# crate = "ring"
 # The SPDX expression for the license requirements of the crate
-#expression = "MIT AND ISC AND OpenSSL"
+# expression = "MIT AND ISC AND OpenSSL"
 # One or more files in the crate's source used as the "source of truth" for
 # the license expression. If the contents match, the clarification will be used
 # when running the license check, otherwise the clarification will be ignored
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
-#license-files = [
+# license-files = [
 # Each entry is a crate relative path, and the (opaque) hash of its contents
-#{ path = "LICENSE", hash = 0xbd0eed23 }
-#]
+# { path = "LICENSE", hash = 0xbd0eed23 }
+# ]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
@@ -128,7 +129,7 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-    #"https://sekretz.com/registry
+  # "https://sekretz.com/registry
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -155,27 +156,27 @@ workspace-default-features = "allow"
 external-default-features = "allow"
 # List of crates that are allowed. Use with care!
 allow = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+  # "ansi_term@0.11.0",
+  # { crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
 ]
 # List of crates to deny
 deny = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+  # "ansi_term@0.11.0",
+  # { crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+  # Wrapper crates can optionally be specified to allow the crate when it
+  # is a direct dependency of the otherwise banned crate
+  # { crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
 ]
 
 # List of features to allow/deny
 # Each entry the name of a crate and a version range. If version is
 # not specified, all versions will be matched.
-#[[bans.features]]
-#crate = "reqwest"
+# [[bans.features]]
+# crate = "reqwest"
 # Features to not allow
-#deny = ["json"]
+# deny = ["json"]
 # Features to allow
-#allow = [
+# allow = [
 #    "rustls",
 #    "__rustls",
 #    "__tls",
@@ -185,23 +186,23 @@ deny = [
 #    "rustls-tls-webpki-roots",
 #    "tokio-rustls",
 #    "webpki-roots",
-#]
+# ]
 # If true, the allowed features must exactly match the enabled feature set. If
 # this is set there is no point setting `deny`
-#exact = true
+# exact = true
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+  # "ansi_term@0.11.0",
+  # { crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite.
 skip-tree = [
-    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
-    #{ crate = "ansi_term@0.11.0", depth = 20 },
+  # "ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+  # { crate = "ansi_term@0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/eddsa-babyjubjub/Cargo.toml
+++ b/eddsa-babyjubjub/Cargo.toml
@@ -18,7 +18,7 @@ ark-serialize = { workspace = true }
 blake3 = { workspace = true }
 eyre = { workspace = true }
 num-bigint.workspace = true
-poseidon2 = { package = "taceo-poseidon2", path = "../poseidon2", version = "0.2.1", features = [
+poseidon2 = { package = "taceo-poseidon2", path = "../poseidon2", version = "0.2.1", default-features = false, features = [
   "bn254",
   "t8"
 ] }

--- a/eddsa-babyjubjub/Cargo.toml
+++ b/eddsa-babyjubjub/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 publish = true
 
 [dependencies]
-ark-babyjubjub = { package = "taceo-ark-babyjubjub", version = ">=0.5.3" }
+ark-babyjubjub = { package = "taceo-ark-babyjubjub", path = "../ark-babyjubjub", version = "0.5.3" }
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 ark-serde-compat = { workspace = true }
@@ -18,7 +18,13 @@ ark-serialize = { workspace = true }
 blake3 = { workspace = true }
 eyre = { workspace = true }
 num-bigint.workspace = true
-poseidon2 = { workspace = true, features = ["bn254", "t8"] }
+poseidon2 = { package = "taceo-poseidon2", path = "../poseidon2", version = "0.2.1", features = [
+  "bn254",
+  "t8"
+] }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 zeroize = { workspace = true }
+
+[patch.crates-io]
+taceo-ark-babyjubjub = { path = "ark-babyjubjub" }

--- a/eddsa-babyjubjub/Cargo.toml
+++ b/eddsa-babyjubjub/Cargo.toml
@@ -25,6 +25,3 @@ poseidon2 = { package = "taceo-poseidon2", path = "../poseidon2", version = "0.2
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 zeroize = { workspace = true }
-
-[patch.crates-io]
-taceo-ark-babyjubjub = { path = "ark-babyjubjub" }

--- a/eddsa-babyjubjub/src/lib.rs
+++ b/eddsa-babyjubjub/src/lib.rs
@@ -112,8 +112,7 @@ impl EdDSAPrivateKey {
 /// A public key for the EdDSA signature scheme over the BabyJubJubCurve.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EdDSAPublicKey {
-    #[serde(serialize_with = "ark_serde_compat::babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "ark_serde_compat::babyjubjub::deserialize_affine")]
+    #[serde(with = "ark_serde_compat::babyjubjub::affine")]
     pub pk: Affine,
 }
 
@@ -178,11 +177,9 @@ impl EdDSAPublicKey {
 /// An EdDSA signature on the Baby Jubjub curve, using Poseidon2 as the internal hash function for the Fiat-Shamir transform.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EdDSASignature {
-    #[serde(serialize_with = "ark_serde_compat::babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "ark_serde_compat::babyjubjub::deserialize_affine")]
+    #[serde(with = "ark_serde_compat::babyjubjub::affine")]
     pub r: Affine,
-    #[serde(serialize_with = "ark_serde_compat::serialize_f")]
-    #[serde(deserialize_with = "ark_serde_compat::deserialize_f")]
+    #[serde(with = "ark_serde_compat::field")]
     pub s: ScalarField,
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly build/config changes, but it updates dependency versions and serialization annotations on public key/signature types, which could affect downstream interoperability if encoding changes.
> 
> **Overview**
> Updates workspace dependency wiring to prefer local sub-crates: adds a crates.io patch for `taceo-ark-babyjubjub`, pins `eddsa-babyjubjub` to local path deps for `taceo-ark-babyjubjub` and `taceo-poseidon2`, and bumps `taceo-ark-serde-compat` to `0.5`.
> 
> Adjusts `serde` integration in `eddsa-babyjubjub` by switching `EdDSAPublicKey` and `EdDSASignature` field annotations to the new `ark_serde_compat` module helpers (`babyjubjub::affine` and `field`).
> 
> Tweaks `deny.toml` to add an ignored advisory (`RUSTSEC-2026-0097`) and mostly reformat/comment styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d45c94bce4d47d4c76f64090348cc205d2fcc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->