### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Adds `.github/dependabot.yml` with weekly updates for each Dependabot ecosystem mapped from the detected languages on the default branch.

Detected languages: Just,Rust,Sage

- Weekly updates for `github-actions`
- Weekly updates for `cargo`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts Dependabot configuration to rate-limit update PRs; no production code or runtime behavior is affected.
> 
> **Overview**
> Adds a **3-day `cooldown`** to the weekly Dependabot update configuration for `github-actions` and `cargo`, reducing how frequently new update PRs can be opened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aa7446c3cdd4f04f9341473d96affc512bfcb49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->