### PR TITLE
ci: add minimal permissions to GitHub workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   cargo-deny:

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -8,6 +8,9 @@ on:
       - v*
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   # incremental builds are slower and don't make much sense in ci
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -8,6 +8,9 @@ on:
       - v*
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   # incremental builds are slower and don't make much sense in ci
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to `rust_test.yml` and `rust_lint.yml` workflows that were missing permissions
- Replace overly broad `permissions: read-all` with minimal `permissions: contents: read` in `audit.yml`
- `release-plz.yml` and `rolling.yml` already had appropriate minimal permissions

This follows the principle of least privilege for GitHub Actions workflows.

## Test plan
- [ ] Verify CI workflows still pass with the new permission settings

Slack thread: https://taceo-labs.slack.com/archives/C0AT60XB2HJ/p1777550087135139

https://claude.ai/code/session_0144kFsqQGZ9CktZPSAk4qNv

---
_Generated by [Claude Code](https://claude.ai/code/session_0144kFsqQGZ9CktZPSAk4qNv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limits GitHub Actions token scope to `contents: read` for Rust CI and dependency audit workflows; risk is low but CI could fail if any job implicitly relied on broader default/read-all permissions.
> 
> **Overview**
> Tightens GitHub Actions least-privilege by explicitly setting `permissions: contents: read` on the Rust `lint` and `test` workflows.
> 
> Also replaces the overly broad `read-all` permission in the dependency audit workflow with the same minimal `contents: read` scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92cd262fa38512d039b230fda55232e496959c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->