### PR TITLE
build(deps)!: update arkworks to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,16 @@ repository = "https://github.com/TaceoLabs/eddsa-babyjubjub"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-ark-algebra-test-templates = "0.5"
-ark-bn254 = "0.5"
-ark-curve-constraint-tests = "0.5"
-ark-ec = { version = "0.5", default-features = false }
-ark-ff = { version = "0.5", default-features = false }
-ark-groth16 = { version = "0.5", default-features = false }
-ark-r1cs-std = { version = "0.5", default-features = false }
-ark-relations = { version = "0.5", default-features = false }
-ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.5", default-features = false, features = [
-  "babyjubjub"
-] }
-ark-serialize = { version = "0.5", default-features = false }
-ark-std = "0.5"
+ark-algebra-test-templates = "0.6"
+ark-bn254 = "0.6"
+ark-curve-constraint-tests = "0.6"
+ark-ec = { version = "0.6", default-features = false }
+ark-ff = { version = "0.6", default-features = false }
+ark-groth16 = { version = "0.6", default-features = false }
+ark-r1cs-std = { version = "0.6", default-features = false }
+ark-relations = { version = "0.6", default-features = false }
+ark-serialize = { version = "0.6", default-features = false }
+ark-std = "0.6"
 blake3 = "1"
 eyre = "0.6"
 num-bigint = "0.4"
@@ -33,7 +30,7 @@ num-traits = "0.2"
 rand = "0.8"
 serde = { version = "1" }
 thiserror = "2"
-zeroize = "1"
+zeroize = { version = "1", features = ["derive"] }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
@@ -56,9 +53,6 @@ unwrap_used = "deny"
 [workspace.lints.rust]
 missing_docs = "deny"
 unsafe_code = "forbid"
-
-[patch.crates-io]
-taceo-ark-babyjubjub = { path = "ark-babyjubjub" }
 
 # This profile can be used for CI in pull requests.
 [profile.ci-dev]

--- a/ark-babyjubjub/src/constraints/mod.rs
+++ b/ark-babyjubjub/src/constraints/mod.rs
@@ -10,9 +10,9 @@
 //! One can perform standard algebraic operations on `FqVar`:
 //!
 //! ```
-//! # fn main() -> Result<(), ark_relations::r1cs::SynthesisError> {
+//! # fn main() -> Result<(), ark_relations::gr1cs::SynthesisError> {
 //! use ark_std::UniformRand;
-//! use ark_relations::r1cs::*;
+//! use ark_relations::gr1cs::*;
 //! use ark_r1cs_std::prelude::*;
 //! use taceo_ark_babyjubjub::{*, constraints::*};
 //!
@@ -59,9 +59,9 @@
 //! One can also perform standard algebraic operations on `EdwardsVar`:
 //!
 //! ```
-//! # fn main() -> Result<(), ark_relations::r1cs::SynthesisError> {
+//! # fn main() -> Result<(), ark_relations::gr1cs::SynthesisError> {
 //! # use ark_std::UniformRand;
-//! # use ark_relations::r1cs::*;
+//! # use ark_relations::gr1cs::*;
 //! # use ark_r1cs_std::prelude::*;
 //! # use taceo_ark_babyjubjub::{*, constraints::*};
 //!

--- a/deny.toml
+++ b/deny.toml
@@ -23,13 +23,13 @@
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
 targets = [
-  # The triple can be any string, but only the target triples built in to
-  # rustc (as of 1.40) can be checked against actual config expressions
-  # "x86_64-unknown-linux-musl",
-  # You can also specify which target_features you promise are enabled for a
-  # particular target. target_features are currently not validated against
-  # the actual valid features supported by the target architecture.
-  # { triple = "wasm32-unknown-unknown", features = ["atomics"] },
+ # The triple can be any string, but only the target triples built in to
+ # rustc (as of 1.40) can be checked against actual config expressions
+ # "x86_64-unknown-linux-musl",
+ # You can also specify which target_features you promise are enabled for a
+ # particular target. target_features are currently not validated against
+ # the actual valid features supported by the target architecture.
+ # { triple = "wasm32-unknown-unknown", features = ["atomics"] },
 ]
 # When creating the dependency graph used as the source of truth when checks are
 # executed, this field can be used to prune crates from the graph, removing them
@@ -70,9 +70,8 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-  { id = "RUSTSEC-2024-0436", reason = "paste no longer maintained, dep of arkworks" },
-  { id = "RUSTSEC-2025-0055", reason = "tracing-subscriber, dep of arkworks, only for tests" },
-  { id = "RUSTSEC-2026-0097", reason = "can't upgrade due to transative deps. Doesn't affect us because we don't enable the log feature" },
+ { id = "RUSTSEC-2024-0436", reason = "paste no longer maintained, dep of arkworks" },
+ { id = "RUSTSEC-2026-0097", reason = "can't upgrade due to transative deps. Doesn't affect us because we don't enable the log feature" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -87,7 +86,8 @@ ignore = [
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = ["MIT", "Apache-2.0", "Unicode-3.0", "BSD-2-Clause"]
+# Zlib: foldhash, pulled in by ark-relations 0.6 via hashbrown
+allow = ["MIT", "Apache-2.0", "Unicode-3.0", "BSD-2-Clause", "Zlib"]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
@@ -96,9 +96,9 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-  # Each entry is the crate and version constraint, and its specific allow
-  # list
-  # { allow = ["Zlib"], crate = "adler32" },
+ # Each entry is the crate and version constraint, and its specific allow
+ # list
+ # { allow = ["Zlib"], crate = "adler32" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
@@ -129,7 +129,7 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-  # "https://sekretz.com/registry
+ # "https://sekretz.com/registry
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -156,16 +156,16 @@ workspace-default-features = "allow"
 external-default-features = "allow"
 # List of crates that are allowed. Use with care!
 allow = [
-  # "ansi_term@0.11.0",
-  # { crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+ # "ansi_term@0.11.0",
+ # { crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
 ]
 # List of crates to deny
 deny = [
-  # "ansi_term@0.11.0",
-  # { crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
-  # Wrapper crates can optionally be specified to allow the crate when it
-  # is a direct dependency of the otherwise banned crate
-  # { crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+ # "ansi_term@0.11.0",
+ # { crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+ # Wrapper crates can optionally be specified to allow the crate when it
+ # is a direct dependency of the otherwise banned crate
+ # { crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
 ]
 
 # List of features to allow/deny
@@ -193,16 +193,16 @@ deny = [
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-  # "ansi_term@0.11.0",
-  # { crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+ # "ansi_term@0.11.0",
+ # { crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite.
 skip-tree = [
-  # "ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
-  # { crate = "ansi_term@0.11.0", depth = 20 },
+ # "ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+ # { crate = "ansi_term@0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/eddsa-babyjubjub/Cargo.toml
+++ b/eddsa-babyjubjub/Cargo.toml
@@ -9,16 +9,23 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+# TODO: this crate is held back on arkworks 0.5 until `taceo-ark-serde-compat`
+# 0.6 is published (it in turn needs `taceo-ark-babyjubjub` 0.6, released by
+# this very PR). Until then it builds against the *published* 0.5 releases of
+# its sibling crates instead of the in-tree ones; restore the `path` /
+# `workspace = true` deps once 0.6 of `taceo-ark-serde-compat` is on crates.io.
 [dependencies]
-ark-babyjubjub = { package = "taceo-ark-babyjubjub", path = "../ark-babyjubjub", version = "0.5.3" }
-ark-ec = { workspace = true }
-ark-ff = { workspace = true }
-ark-serde-compat = { workspace = true }
-ark-serialize = { workspace = true }
+ark-babyjubjub = { package = "taceo-ark-babyjubjub", version = "0.5.3" }
+ark-ec = { version = "0.5", default-features = false }
+ark-ff = { version = "0.5", default-features = false }
+ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.5", default-features = false, features = [
+  "babyjubjub"
+] }
+ark-serialize = { version = "0.5", default-features = false }
 blake3 = { workspace = true }
 eyre = { workspace = true }
 num-bigint.workspace = true
-poseidon2 = { package = "taceo-poseidon2", path = "../poseidon2", version = "0.2.1", default-features = false, features = [
+poseidon2 = { package = "taceo-poseidon2", version = "0.2.1", default-features = false, features = [
   "bn254",
   "t8"
 ] }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,3 +1,9 @@
+# Held back on arkworks 0.5 until `taceo-ark-serde-compat` 0.6 is published;
+# re-enable together with restoring the path deps in its manifest.
+[[package]]
+name = "taceo-eddsa-babyjubjub"
+release = false
+
 [changelog]
 header = """# Changelog
 


### PR DESCRIPTION
Bumps all arkworks workspace dependencies (ark-{algebra-test-templates, bn254,curve-constraint-tests,ec,ff,groth16,r1cs-std,relations,serialize, std}) from 0.5 to 0.6. Adds an explicit `features = ["derive"]` on `zeroize`, since arkworks 0.5 was previously enabling it transitively.

`taceo-eddsa-babyjubjub` is held back on arkworks 0.5 for now: it needs `taceo-ark-serde-compat` 0.6, which in turn needs `taceo-ark-babyjubjub` 0.6 — the very release this commit prepares.

BREAKING CHANGE: taceo-ark-babyjubjub and taceo-poseidon2 now build against arkworks 0.6, which is incompatible with 0.5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major breaking crypto/SNARK dependency bump with a split workspace (0.6 vs held-back 0.5 for EdDSA) until the serde-compat publish cycle completes.
> 
> **Overview**
> **Bumps the workspace to arkworks 0.6** across the shared `ark-*` crates and drops the `taceo-ark-serde-compat` workspace dependency plus the `[patch.crates-io]` override for in-tree `taceo-ark-babyjubjub`. **`zeroize` now enables `derive` explicitly** because 0.6 no longer pulls that in transitively.
> 
> **`taceo-eddsa-babyjubjub` stays on arkworks 0.5 for this release**: its manifest pins published `0.5` siblings instead of path/workspace deps (documented TODO), and **release-plz disables publishing** that crate until `taceo-ark-serde-compat` 0.6 can ship after `taceo-ark-babyjubjub` 0.6.
> 
> Constraint **doc examples** in `ark-babyjubjub` switch from `ark_relations::r1cs` to **`gr1cs`** for the 0.6 API. **`cargo-deny`** adds **Zlib** for new transitive licenses, drops one advisory ignore, and has minor formatting-only edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 081e6dc6460aa120c23cbc689cb2e5c40d253413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->