### PR TITLE
build(deps)!: update eddsa-babyjubjub to arkworks 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ ark-ff = { version = "0.6", default-features = false }
 ark-groth16 = { version = "0.6", default-features = false }
 ark-r1cs-std = { version = "0.6", default-features = false }
 ark-relations = { version = "0.6", default-features = false }
+ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.6", default-features = false, features = [
+  "babyjubjub"
+] }
 ark-serialize = { version = "0.6", default-features = false }
 ark-std = "0.6"
 blake3 = "1"
@@ -53,6 +56,11 @@ unwrap_used = "deny"
 [workspace.lints.rust]
 missing_docs = "deny"
 unsafe_code = "forbid"
+
+# So that `taceo-ark-serde-compat` shares the in-tree `taceo-ark-babyjubjub`
+# instead of pulling its own copy from crates.io.
+[patch.crates-io]
+taceo-ark-babyjubjub = { path = "ark-babyjubjub" }
 
 # This profile can be used for CI in pull requests.
 [profile.ci-dev]

--- a/eddsa-babyjubjub/Cargo.toml
+++ b/eddsa-babyjubjub/Cargo.toml
@@ -2,30 +2,24 @@
 name = "taceo-eddsa-babyjubjub"
 version = "0.5.5"
 edition.workspace = true
-rust-version.workspace = true
+# Higher than the workspace MSRV: `taceo-ark-serde-compat` 0.6 requires 1.90.
+rust-version = "1.90"
 description = "An EdDSA signature scheme implementation over the Baby Jubjub elliptic curve using Poseidon2, useful for SNARK-friendliness."
 readme = "./README.md"
 repository.workspace = true
 license.workspace = true
 publish = true
 
-# TODO: this crate is held back on arkworks 0.5 until `taceo-ark-serde-compat`
-# 0.6 is published (it in turn needs `taceo-ark-babyjubjub` 0.6, released by
-# this very PR). Until then it builds against the *published* 0.5 releases of
-# its sibling crates instead of the in-tree ones; restore the `path` /
-# `workspace = true` deps once 0.6 of `taceo-ark-serde-compat` is on crates.io.
 [dependencies]
-ark-babyjubjub = { package = "taceo-ark-babyjubjub", version = "0.5.3" }
-ark-ec = { version = "0.5", default-features = false }
-ark-ff = { version = "0.5", default-features = false }
-ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.5", default-features = false, features = [
-  "babyjubjub"
-] }
-ark-serialize = { version = "0.5", default-features = false }
+ark-babyjubjub = { package = "taceo-ark-babyjubjub", path = "../ark-babyjubjub", version = "0.6.0" }
+ark-ec = { workspace = true }
+ark-ff = { workspace = true }
+ark-serde-compat = { workspace = true }
+ark-serialize = { workspace = true }
 blake3 = { workspace = true }
 eyre = { workspace = true }
 num-bigint.workspace = true
-poseidon2 = { package = "taceo-poseidon2", version = "0.2.1", default-features = false, features = [
+poseidon2 = { package = "taceo-poseidon2", path = "../poseidon2", version = "0.3.0", default-features = false, features = [
   "bn254",
   "t8"
 ] }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,9 +1,3 @@
-# Held back on arkworks 0.5 until `taceo-ark-serde-compat` 0.6 is published;
-# re-enable together with restoring the path deps in its manifest.
-[[package]]
-name = "taceo-eddsa-babyjubjub"
-release = false
-
 [changelog]
 header = """# Changelog
 


### PR DESCRIPTION
Follow-up to #43. `taceo-ark-serde-compat` 0.6 is now published, so `taceo-eddsa-babyjubjub` no longer has to be held back on arkworks 0.5.

- Restores its `path` / `workspace = true` dependencies, so it builds against the in-tree `taceo-ark-babyjubjub` 0.6.0 and `taceo-poseidon2` 0.3.0 again.
- Re-adds `ark-serde-compat` to `[workspace.dependencies]` and the `[patch.crates-io]` entry for `taceo-ark-babyjubjub` — without the latter, `taceo-ark-serde-compat` resolves its own copy from crates.io and the two don't share types.
- Drops the `release = false` hold from `release-plz.toml`.
- Pins this crate's `rust-version` to 1.90 rather than inheriting the workspace's 1.86, since `taceo-ark-serde-compat` 0.6 requires it. `taceo-ark-babyjubjub` and `taceo-poseidon2` keep the lower MSRV.

The version bump is left to release-plz; the `BREAKING CHANGE:` trailer should get it to 0.6.0.

Verified locally: `just lint` and `just test` pass, `cargo deny check advisories bans licenses sources` is clean, and `cargo publish -p taceo-eddsa-babyjubjub --dry-run` succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking dependency upgrade (arkworks 0.6 / expected 0.6.0 release) and a higher MSRV for `taceo-eddsa-babyjubjub`; changes are manifest-only but affect downstream consumers of the published crate.
> 
> **Overview**
> **`taceo-eddsa-babyjubjub` is unblocked from arkworks 0.5** now that `taceo-ark-serde-compat` 0.6 is on crates.io. Its manifest again uses in-tree **`taceo-ark-babyjubjub` 0.6.0** and **`taceo-poseidon2` 0.3.0** plus workspace **arkworks 0.6** deps, with the temporary crates.io 0.5 pins and holdback comments removed.
> 
> At the workspace root, **`ark-serde-compat`** is re-added to `[workspace.dependencies]` and **`[patch.crates-io]`** pins **`taceo-ark-babyjubjub`** so serde-compat does not pull a separate Baby Jubjub crate and type identity stays consistent.
> 
> **Release tooling:** the **`release = false`** override for this crate is dropped from **`release-plz.toml`**. The crate’s **`rust-version`** is set to **1.90** (above the workspace **1.86**) because serde-compat 0.6 requires it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e0c337d08f4116cb7de1a303ad7f232fdf93bef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->