### PR TITLE
Threshold EdDSA based on FROST3 and DKG/Reshare based on PedPOP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [workspace]
 resolver = "3"
 members = [
-  "ark-babyjubjub",
-  "eddsa-babyjubjub",
-  "poseidon2",
+    "ark-babyjubjub",
+    "eddsa-babyjubjub",
+    "poseidon2",
+    "threshold-eddsa-babyjubjub",
 ]
 
 [workspace.package]
@@ -22,17 +23,20 @@ ark-groth16 = { version = "0.6", default-features = false }
 ark-r1cs-std = { version = "0.6", default-features = false }
 ark-relations = { version = "0.6", default-features = false }
 ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.6", default-features = false, features = [
-  "babyjubjub"
+    "babyjubjub",
 ] }
 ark-serialize = { version = "0.6", default-features = false }
 ark-std = "0.6"
 blake3 = "1"
+eddsa-babyjubjub = { package = "taceo-eddsa-babyjubjub", path = "eddsa-babyjubjub" }
 eyre = "0.6"
+itertools = "0.15"
 num-bigint = "0.4"
 num-traits = "0.2"
 rand = "0.8"
 serde = { version = "1" }
 thiserror = "2"
+uuid = "1"
 zeroize = { version = "1", features = ["derive"] }
 
 [workspace.lints.clippy]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ These signatures are friendly to verify in SNARK systems working over the BN254 
 * `ark-serde-compat`: A few helper functions for serializing arkworks types with serde.
 * `eddsa-babyjubjub`: An implementation of EdDSA over the BabyJubJub curve.
 * `poseidon2`: An implementation of the SNARK-friendly Poseidon2 hash function over the BN254 scalar field.
+* `threshold-eddsa-babyjubjub`: A threshold implementation of `eddsa-babyjubjub` using Frost3.
 
 Since there is no namespace support on crates.io, the above crates are published with a `taceo-` prefix, to not add confusion whether these belong to the arkworks ecosystem or not (e.g., `taceo-ark-babyjubjub`).
 This might change in the future, once namespaces are available.

--- a/eddsa-babyjubjub/src/lib.rs
+++ b/eddsa-babyjubjub/src/lib.rs
@@ -236,7 +236,9 @@ impl EdDSASignature {
     }
 }
 
-fn challenge_hash(message: BaseField, nonce_r: Affine, pk: Affine) -> BaseField {
+/// The challenge hash for the `EdDSA` signature scheme, using Poseidon2 as the internal hash function for the Fiat-Shamir transform.
+#[must_use]
+pub fn challenge_hash(message: BaseField, nonce_r: Affine, pk: Affine) -> BaseField {
     poseidon2::bn254::t8::permutation(&[
         EdDSASignature::get_chall_ds(), // Domain separator in capacity element
         nonce_r.x,
@@ -249,8 +251,9 @@ fn challenge_hash(message: BaseField, nonce_r: Affine, pk: Affine) -> BaseField 
     ])[1]
 }
 
-// This is just a modular reduction. We show in the docs why this does not introduce a bias when applied to a uniform element of the base field.
-pub(crate) fn convert_base_to_scalar(f: BaseField) -> ScalarField {
+/// This is just a modular reduction. We show in the docs why this does not introduce a bias when applied to a uniform element of the base field.
+#[must_use]
+pub fn convert_base_to_scalar(f: BaseField) -> ScalarField {
     let bytes = f.into_bigint().to_bytes_le();
     ScalarField::from_le_bytes_mod_order(&bytes)
 }

--- a/threshold-eddsa-babyjubjub/Cargo.toml
+++ b/threshold-eddsa-babyjubjub/Cargo.toml
@@ -33,3 +33,6 @@ workspace = true
 [features]
 default = []
 additive = []
+
+[dev-dependencies]
+serde_json = "1"

--- a/threshold-eddsa-babyjubjub/Cargo.toml
+++ b/threshold-eddsa-babyjubjub/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "taceo-threshold-eddsa-babyjubjub"
+version = "0.1.0"
+edition.workspace = true
+# Higher than the workspace MSRV: `taceo-ark-serde-compat` 0.6 requires 1.90.
+rust-version = "1.90"
+description = "A threshold EdDSA signature scheme implementation over the Baby Jubjub elliptic curve using Frost3 and Poseidon2, useful for SNARK-friendliness."
+readme = "./README.md"
+repository.workspace = true
+license.workspace = true
+publish = true
+
+[dependencies]
+ark-babyjubjub = { package = "taceo-ark-babyjubjub", path = "../ark-babyjubjub", version = "0.6.0" }
+blake3 = { workspace = true }
+ark-ec = { workspace = true }
+ark-ff = { workspace = true }
+ark-serde-compat = { workspace = true }
+ark-serialize = { workspace = true }
+eddsa-babyjubjub = { workspace = true }
+itertools = { workspace = true }
+num-bigint = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+zeroize = { workspace = true }
+
+[lints]
+workspace = true
+
+[features]
+default = []
+additive = []

--- a/threshold-eddsa-babyjubjub/Cargo.toml
+++ b/threshold-eddsa-babyjubjub/Cargo.toml
@@ -16,19 +16,20 @@ blake3 = { workspace = true }
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 ark-serde-compat = { workspace = true }
-ark-serialize = { workspace = true }
+ark-serialize = { workspace = true, features = ["serde"] }
 eddsa-babyjubjub = { workspace = true }
+eyre = { workspace = true }
 itertools = { workspace = true }
 num-bigint = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
 zeroize = { workspace = true }
 
 [lints]
 workspace = true
 
 [features]
-default = []
+default = ["additive"]
 additive = []

--- a/threshold-eddsa-babyjubjub/Cargo.toml
+++ b/threshold-eddsa-babyjubjub/Cargo.toml
@@ -31,5 +31,5 @@ zeroize = { workspace = true }
 workspace = true
 
 [features]
-default = ["additive"]
+default = []
 additive = []

--- a/threshold-eddsa-babyjubjub/README.md
+++ b/threshold-eddsa-babyjubjub/README.md
@@ -67,7 +67,7 @@ only by an unauthenticated transport.
 | Reshare polynomial commitments and proof of possession | **Reliable broadcast from each selected old sender to every new party** | A sender must not equivocate about the polynomial against which private evaluations are checked. |
 | Reshare polynomial evaluations | **Private, authenticated point-to-point channel** | Each new party receives a different secret evaluation. |
 | Reshare complaint verdicts and old-sender revelations | **Reliable broadcast to every new party** | Every new party must derive the same surviving sender set and public output. |
-| Missing-revelation timeout decisions | **Externally coordinated agreement** | Every honest participant must disqualify the same missing dealer or sender. |
+| Missing-message, verdict, and revelation timeout decisions | **Externally coordinated agreement** | Every honest participant must apply the same disqualification or verdict-exclusion set. |
 
 Reliable broadcast means more than best-effort multicast. In particular, if one
 honest participant accepts a broadcast from a sender, all honest participants
@@ -80,11 +80,13 @@ point-to-point copies.
 The primary API is in the `shamir` module:
 
 - `EdDSASessionShamir::pre_round` samples two secret, single-use nonces and
-  returns their public `PartialEdDSACommitmentsShamir`.
-- The aggregator selects a canonically ordered signing set of at least the
-  threshold size and calls `EdDSACommitmentsShamir::pre_agg`.
-- Each selected party computes its Lagrange coefficient for exactly that set
-  and consumes its session with `EdDSASessionShamir::sign_round`.
+  returns their public, identity-bound `PartialEdDSACommitmentsShamir`.
+- The aggregator selects a signing set of at least the threshold size and calls
+  `EdDSACommitmentsShamir::pre_agg`; aggregation canonicalizes the party order
+  and rejects empty or duplicate sets.
+- Each selected party consumes its session with
+  `EdDSASessionShamir::sign_round`. The signer validates its identity and
+  committee metadata and derives its Lagrange coefficient internally.
 - The aggregator calls `sign_agg` or, when public-key shares and individual
   commitments are available, `sign_agg_with_identifiable_abort`.
 
@@ -100,8 +102,10 @@ signers                         aggregator
    |                                `--> ordinary EdDSA signature
 ```
 
-The signer order must match across party IDs, signature shares, public-key
-shares, and individual nonce commitments. Prefer
+Commitments and signature shares carry party IDs, and public-key shares used
+for identifiable abort are supplied in a `BTreeMap<u16, Affine>`. The map must
+come from authenticated, immutable DKG or reshare output; the type system cannot
+authenticate application-provided public-key metadata. Prefer
 `sign_agg_with_identifiable_abort` when an invalid share must be attributed;
 plain `sign_agg` only combines shares and may therefore return a signature that
 does not verify if a participant supplied a malformed share.
@@ -122,7 +126,11 @@ degree is `t - 1`; any `t` resulting shares can sign.
 1. Every party creates `keygen::round1::RoundOne` with identical parameters and
    session ID. It reliably broadcasts `get_broadcast_message()`, containing its
    coefficient commitments and Schnorr proof of possession. Every other party
-   passes that same broadcast to `add_party_communication`.
+   passes that same broadcast to `add_party_communication`. A missing or
+   malformed round-one dealer can be excluded with `disqualify_party`, but only
+   after all honest parties agree on that decision. For duplicate constant
+   commitments, apply both reported IDs atomically with `disqualify_parties`;
+   this removes broadcasts accepted before the duplicate was discovered.
 2. After `can_advance()` succeeds, `round2()` creates one secret polynomial
    evaluation per recipient. Deliver each `get_party_communication(recipient)`
    privately and authentically, and process it with `add_party_communication`.
@@ -137,6 +145,16 @@ its `revelation()`. Missing revelations may be resolved with
 `disqualify_missing_dealer`, but only after an externally agreed deadline that
 all honest parties apply identically. `BlameRound::finalize` excludes
 disqualified dealers and reports their IDs.
+
+If a selected dealer's private round-two evaluation never arrives, call
+`complain_missing_party` after an externally agreed delivery deadline, then
+enter the blame round. The dealer can reveal the committed evaluation publicly
+or be disqualified under the same coordinated rule.
+
+If a qualified dealer withholds or sends an invalid blame verdict, the remaining
+parties can apply `disqualify_missing_verdict` after a common timeout. Its
+polynomial is removed from the DKG output. Disqualification fails—and the run
+must abort—if fewer than the configured threshold parties would remain.
 
 The direct `add_party_communication` path reports a malformed private share as
 an error and is suitable when the caller will abort the whole run. Use the blame
@@ -169,6 +187,18 @@ decision. Finalization recomputes Lagrange coefficients over the surviving old
 senders, requires at least the old threshold to remain, and checks that their
 constant commitments still reconstruct the original public key.
 
+When a valid sender broadcast arrives but its private evaluation does not, use
+`complain_missing_share` to enter blame and request a public revelation. When
+no usable broadcast arrives, `disqualify_missing_sender` may exclude that sender
+before blame, provided the remaining selected senders still reconstruct the old
+key.
+
+If a new receiver withholds or sends an invalid blame verdict, the completing
+receivers can apply `exclude_missing_verdict` after a common timeout. This only
+removes the receiver from the blame barrier and does not revoke a secret share
+it may already possess. At least the new threshold number of receivers must
+remain. The exclusion is reported in `BlameResult::excluded_verdict_parties`.
+
 Do not let each receiver choose its own sender set or independently decide which
 senders timed out. Doing so can create divergent shares and public-key-share
 metadata even when every local cryptographic check succeeds.
@@ -177,8 +207,9 @@ metadata even when every local cryptographic check succeeds.
 
 DKG and reshare return `keygen::finished::Finished<C>`. For Baby Jubjub, use
 `ark_babyjubjub::EdwardsProjective` as `C`. Its `sk_share` can be converted into
-`shamir::secret::DLogShareShamir` for signing; `pk` and `pk_shares` supply the
-public values required for verification and identifiable abort.
+`shamir::secret::DLogShareShamir` for signing by binding the share to its party
+ID, total party count, and threshold; `pk` and `pk_shares` supply the public
+values required for verification and identifiable abort.
 
 The final threshold signature is an
 `eddsa_babyjubjub::EdDSASignature` and is verified exactly like a regular

--- a/threshold-eddsa-babyjubjub/README.md
+++ b/threshold-eddsa-babyjubjub/README.md
@@ -1,0 +1,203 @@
+# Threshold EdDSA over Baby Jubjub
+
+Threshold signing, distributed key generation, and key resharing for the
+Poseidon2-based Baby Jubjub EdDSA implementation in
+[`taceo-eddsa-babyjubjub`](../eddsa-babyjubjub).
+
+The signing protocol is an adaptation of **FROST3**, the semi-interactive
+threshold Schnorr construction described in
+[ROAST: Robust Asynchronous Schnorr Threshold Signatures](https://eprint.iacr.org/2022/550.pdf).
+It produces an ordinary `EdDSASignature`, so the result is verified with the
+existing single-party `EdDSAPublicKey::verify` API. The distributed key
+generation (DKG) and resharing protocols follow the PedPoP-based algorithms in
+the [TACEO OPRF protocol documentation](https://github.com/TaceoLabs/oprf-service/tree/main/docs).
+
+> [!WARNING]
+> **Key generation and resharing require reliable broadcast for the messages
+> marked “reliable broadcast” below.** Sending a message separately to every
+> participant is not sufficient: a malicious sender must not be able to make
+> two honest participants accept different messages for the same protocol step.
+> The application must provide agreement, sender authentication, duplicate
+> suppression, and consistent timeout/disqualification decisions.
+>
+> This crate does not implement networking, reliable broadcast, participant
+> authentication, persistence, or timeouts. Supplying these is the integrator's
+> responsibility. A consensus-backed ledger, a smart contract, or a dedicated
+> Byzantine reliable-broadcast protocol are possible implementations.
+
+## Features
+
+- `t`-out-of-`n` EdDSA signing with Shamir-shared keys.
+- A FROST3 two-nonce preprocessing round that can run before the message is
+  known, followed by one signing round.
+- Binding of the signer set, session ID, aggregate nonce commitments, public
+  key, and message into the BLAKE3 nonce-combining hash.
+- Poseidon2 for the final EdDSA Fiat-Shamir challenge.
+- Signature-share aggregation with optional identifiable abort.
+- PedPoP-style dealerless DKG, including an optional public complaint round.
+- Resharing to a different party set and/or threshold without changing or
+  reconstructing the signing key.
+- Serde support for protocol messages and zeroization of secret state on drop.
+- An `n`-out-of-`n` additive-sharing variant behind the `additive` feature.
+
+The package name is `taceo-threshold-eddsa-babyjubjub`. The crate currently
+requires Rust 1.90 or newer.
+
+```toml
+[dependencies]
+taceo-threshold-eddsa-babyjubjub = "0.1"
+
+# Also expose the n-out-of-n additive variant:
+# taceo-threshold-eddsa-babyjubjub = { version = "0.1", features = ["additive"] }
+```
+
+## Network requirements
+
+The protocol APIs operate on already-delivered messages. Bind the externally
+authenticated sender identity to the `from` argument; never trust an ID carried
+only by an unauthenticated transport.
+
+| Protocol step | Required channel | Why |
+| --- | --- | --- |
+| FROST3 preprocessing commitments and signature shares | **Authenticated signer-to-aggregator communication** | The aggregator must attribute each contribution to the correct signer. Reliable broadcast is not required for the signing flow implemented here. |
+| DKG round-one polynomial commitments and proof of possession | **Reliable broadcast to every DKG party** | All honest parties must use the same commitments and derive the same public key and public-key shares. |
+| DKG round-two polynomial evaluations | **Private, authenticated point-to-point channel** | Each evaluation is a secret intended only for its recipient. |
+| DKG complaint verdicts and dealer revelations | **Reliable broadcast to every DKG party** | All honest parties must see the same accusation set, revelations, and qualified dealer set. |
+| Reshare sender set, old/new parameters, public key, public-key shares, and session ID | **Global agreement before starting** | Every old sender and new receiver must execute the same handover. |
+| Reshare polynomial commitments and proof of possession | **Reliable broadcast from each selected old sender to every new party** | A sender must not equivocate about the polynomial against which private evaluations are checked. |
+| Reshare polynomial evaluations | **Private, authenticated point-to-point channel** | Each new party receives a different secret evaluation. |
+| Reshare complaint verdicts and old-sender revelations | **Reliable broadcast to every new party** | Every new party must derive the same surviving sender set and public output. |
+| Missing-revelation timeout decisions | **Externally coordinated agreement** | Every honest participant must disqualify the same missing dealer or sender. |
+
+Reliable broadcast means more than best-effort multicast. In particular, if one
+honest participant accepts a broadcast from a sender, all honest participants
+that complete the step must accept the same payload from that sender. Do not
+advance merely because a local node has received enough mutually inconsistent
+point-to-point copies.
+
+## Threshold signing
+
+The primary API is in the `shamir` module:
+
+- `EdDSASessionShamir::pre_round` samples two secret, single-use nonces and
+  returns their public `PartialEdDSACommitmentsShamir`.
+- The aggregator selects a canonically ordered signing set of at least the
+  threshold size and calls `EdDSACommitmentsShamir::pre_agg`.
+- Each selected party computes its Lagrange coefficient for exactly that set
+  and consumes its session with `EdDSASessionShamir::sign_round`.
+- The aggregator calls `sign_agg` or, when public-key shares and individual
+  commitments are available, `sign_agg_with_identifiable_abort`.
+
+The high-level message flow is:
+
+```text
+signers                         aggregator
+   |-- pre-round commitments ------>|
+   |                                | select signer set T
+   |<-- (session ID, T, aggregate commitments, public key, message)
+   |-- signature shares ----------->|
+   |                                | aggregate and verify
+   |                                `--> ordinary EdDSA signature
+```
+
+The signer order must match across party IDs, signature shares, public-key
+shares, and individual nonce commitments. Prefer
+`sign_agg_with_identifiable_abort` when an invalid share must be attributed;
+plain `sign_agg` only combines shares and may therefore return a signature that
+does not verify if a participant supplied a malformed share.
+
+### Nonce and session safety
+
+`EdDSASessionShamir` deliberately cannot be cloned and `sign_round` consumes it.
+Never reuse or restore its nonce state. Use a fresh, globally unique UUID for
+each logical signing attempt, and ensure every participant agrees on the same
+session ID, signer set, public key, and message. Secret-key shares and DKG or
+reshare polynomial evaluations must be stored and transported as secrets.
+
+## Distributed key generation
+
+`keygen::Parameters::new(n, t)` configures an `n`-party sharing whose polynomial
+degree is `t - 1`; any `t` resulting shares can sign.
+
+1. Every party creates `keygen::round1::RoundOne` with identical parameters and
+   session ID. It reliably broadcasts `get_broadcast_message()`, containing its
+   coefficient commitments and Schnorr proof of possession. Every other party
+   passes that same broadcast to `add_party_communication`.
+2. After `can_advance()` succeeds, `round2()` creates one secret polynomial
+   evaluation per recipient. Deliver each `get_party_communication(recipient)`
+   privately and authentically, and process it with `add_party_communication`.
+3. In the all-honest path, `finalize()` returns `keygen::finished::Finished`,
+   containing the local secret share, every public-key share, and the aggregate
+   public key.
+
+For a complaint-capable run, receive round-two shares with
+`add_party_communication_for_blame`, enter `blame_round()`, and reliably
+broadcast every party's `verdict()`. Each accused dealer then reliably broadcasts
+its `revelation()`. Missing revelations may be resolved with
+`disqualify_missing_dealer`, but only after an externally agreed deadline that
+all honest parties apply identically. `BlameRound::finalize` excludes
+disqualified dealers and reports their IDs.
+
+The direct `add_party_communication` path reports a malformed private share as
+an error and is suitable when the caller will abort the whole run. Use the blame
+path when the caller needs public resolution and a consistently qualified
+dealer set.
+
+## Resharing
+
+Resharing replaces the Shamir sharing while preserving the secret key and
+public key. It can change `n`, change `t`, rotate participants, or refresh shares
+for the same configuration.
+
+1. All participants first agree on identical old and new `Parameters`, the old
+   public key, a fresh session ID, and a selected old-party sender set containing
+   at least the old threshold. Build it with
+   `ReShareSenderSet::for_pk_and_parameters`, `add_party`, and `correct`.
+2. Each selected old party creates a `ReShareProtocolSender`. Its polynomial
+   commitment from `get_broadcast_message()` requires reliable broadcast to all
+   new parties. Its `get_party_communication(new_party)` result is delivered
+   privately to that new party. These two deliveries may happen in parallel.
+3. Each new party creates a `ReShareProtocolReceiver`, adds every selected old
+   sender's broadcast and private message with
+   `add_old_party_communication`, and calls `finalize()`.
+
+For public complaint handling, use
+`add_old_party_communication_for_blame`, then enter `blame_round()`. Verdicts
+from the new parties and revelations from accused old senders both require
+reliable broadcast. Apply `disqualify_missing_sender` only from a common timeout
+decision. Finalization recomputes Lagrange coefficients over the surviving old
+senders, requires at least the old threshold to remain, and checks that their
+constant commitments still reconstruct the original public key.
+
+Do not let each receiver choose its own sender set or independently decide which
+senders timed out. Doing so can create divergent shares and public-key-share
+metadata even when every local cryptographic check succeeds.
+
+## Outputs and interoperability
+
+DKG and reshare return `keygen::finished::Finished<C>`. For Baby Jubjub, use
+`ark_babyjubjub::EdwardsProjective` as `C`. Its `sk_share` can be converted into
+`shamir::secret::DLogShareShamir` for signing; `pk` and `pk_shares` supply the
+public values required for verification and identifiable abort.
+
+The final threshold signature is an
+`eddsa_babyjubjub::EdDSASignature` and is verified exactly like a regular
+signature:
+
+```rust,ignore
+let valid = public_key.verify(message, &signature);
+```
+
+## References
+
+- Tim Ruffing et al., [ROAST: Robust Asynchronous Schnorr Threshold
+  Signatures](https://eprint.iacr.org/2022/550.pdf), especially the FROST3
+  signing algorithms and identifiable-abort construction.
+- TACEO, [OPRF protocol documentation](https://github.com/TaceoLabs/oprf-service/tree/main/docs),
+  section “Key Generation and Reshare” ([PDF](https://github.com/TaceoLabs/oprf-service/blob/main/docs/oprf.pdf),
+  [Typst source](https://github.com/TaceoLabs/oprf-service/blob/main/docs/oprf.typst)).
+
+## License
+
+Licensed under either of Apache License, Version 2.0 or the MIT license, at your
+option.

--- a/threshold-eddsa-babyjubjub/README.md
+++ b/threshold-eddsa-babyjubjub/README.md
@@ -66,7 +66,8 @@ only by an unauthenticated transport.
 | Reshare sender set, old/new parameters, public key, public-key shares, and session ID | **Global agreement before starting** | Every old sender and new receiver must execute the same handover. |
 | Reshare polynomial commitments and proof of possession | **Reliable broadcast from each selected old sender to every new party** | A sender must not equivocate about the polynomial against which private evaluations are checked. |
 | Reshare polynomial evaluations | **Private, authenticated point-to-point channel** | Each new party receives a different secret evaluation. |
-| Reshare complaint verdicts and old-sender revelations | **Reliable broadcast to every new party** | Every new party must derive the same surviving sender set and public output. |
+| Reshare complaint verdicts | **Reliable broadcast to every new party _and_ to every selected old sender** | Every new party must derive the same surviving sender set and public output. An accused old sender derives from these verdicts which evaluations it must reveal, so a sender that accepts unauthenticated verdicts can be induced to publish evaluations of a polynomial whose constant term is its own secret key share. |
+| Reshare old-sender revelations | **Reliable broadcast to every new party** | Every new party must apply the same revelation or disqualification. |
 | Missing-message, verdict, and revelation timeout decisions | **Externally coordinated agreement** | Every honest participant must apply the same disqualification or verdict-exclusion set. |
 
 Reliable broadcast means more than best-effort multicast. In particular, if one
@@ -86,7 +87,10 @@ The primary API is in the `shamir` module:
   and rejects empty or duplicate sets.
 - Each selected party consumes its session with
   `EdDSASessionShamir::sign_round`. The signer validates its identity and
-  committee metadata and derives its Lagrange coefficient internally.
+  committee metadata and derives both its Lagrange coefficient and the public key
+  internally, from the `DLogShareShamir` it was given. `sign_round` takes no
+  public key argument, so a signer cannot be pointed at a key it does not hold a
+  share of.
 - The aggregator calls `sign_agg` or, when public-key shares and individual
   commitments are available, `sign_agg_with_identifiable_abort`.
 
@@ -109,6 +113,19 @@ authenticate application-provided public-key metadata. Prefer
 `sign_agg_with_identifiable_abort` when an invalid share must be attributed;
 plain `sign_agg` only combines shares and may therefore return a signature that
 does not verify if a participant supplied a malformed share.
+
+`sign_agg_with_identifiable_abort` fails with `IdentifiableAbortError`, which
+separates the two outcomes that must not be conflated:
+`MaliciousParties` names the parties whose share failed validation, while
+`InvalidInput` means the aggregator's own inputs were inconsistent, so nothing
+was validated and nobody may be accused. Read the attribution with
+`IdentifiableAbortError::malicious_parties`; logging the error alone discards it.
+
+A `DLogShareShamir` binds its scalar to a party ID, the committee size, the
+threshold, and the public key. Build it with `DLogShareShamir::new`, which
+rejects out-of-range metadata and a small-order public key; deserialization
+enforces the same invariants, so a persisted share cannot be loaded with its
+binding altered.
 
 ### Nonce and session safety
 
@@ -145,6 +162,31 @@ its `revelation()`. Missing revelations may be resolved with
 `disqualify_missing_dealer`, but only after an externally agreed deadline that
 all honest parties apply identically. `BlameRound::finalize` excludes
 disqualified dealers and reports their IDs.
+
+`revelation()` derives its accuser set from the collected verdicts rather than
+from a caller-supplied list, so a dealer never answers a party that did not
+complain. It also refuses once the accuser set reaches the threshold, since that
+many evaluations determine the dealer's whole polynomial. Under the `t - 1`
+corruption bound this cannot occur for an honest dealer, because an honest party
+never accuses one.
+
+An accused dealer must feed its own revelation back through `add_revelation`, as
+the broadcast channel delivered it, just as every other party does. `revelation()
+` does not mark the dealer resolved by itself. Otherwise a dealer whose broadcast
+was corrupted or truncated in transit would judge itself qualified while everyone
+else disqualified it, and would silently finalize onto a key nobody else uses.
+
+Following PedPoP, a dealer disqualified in the blame round has its _contribution_
+dropped from the aggregate but remains a shareholder: it completed round two, so
+it holds every qualified dealer's evaluation and can derive its share of the
+surviving polynomial regardless of what the honest parties record. It therefore
+keeps a `pk_shares` entry and `finalize()` returns its share. Its ID is still
+listed in `BlameResult::disqualified_parties`; exclude a proven cheater from
+future signing committees at the application layer if that is the intent.
+Round-one disqualifications are different: those parties never reached round two,
+so they are not shareholders and hold nothing. Every disqualification API refuses
+the decision that would leave fewer than `t` parties, so a run can never silently
+produce an unusable key.
 
 If a selected dealer's private round-two evaluation never arrives, call
 `complain_missing_party` after an externally agreed delivery deadline, then
@@ -186,6 +228,18 @@ reliable broadcast. Apply `disqualify_missing_sender` only from a common timeout
 decision. Finalization recomputes Lagrange coefficients over the surviving old
 senders, requires at least the old threshold to remain, and checks that their
 constant commitments still reconstruct the original public key.
+
+Every selected old sender must receive the new parties' verdicts too, and feed
+them to its `ReShareProtocolSender` with `add_verdict` (plus
+`exclude_missing_verdict` for the same externally agreed timeouts the receivers
+apply). `get_blame_revelation()` then derives the accuser set from those
+verdicts; it takes no accuser argument, so a party that did not complain is
+never answered. The constant term of a sender's resharing polynomial is its own
+secret key share, so `get_blame_revelation()` also refuses once the accuser set
+reaches the new threshold: at that point the revelation would let any observer
+interpolate the share, while the accusers — if honest — already hold enough new
+shares to reconstruct the key anyway. Being disqualified for a missing
+revelation is always preferable to disclosing the share.
 
 When a valid sender broadcast arrives but its private evaluation does not, use
 `complain_missing_share` to enter blame and request a public revelation. When

--- a/threshold-eddsa-babyjubjub/README.md
+++ b/threshold-eddsa-babyjubjub/README.md
@@ -76,6 +76,11 @@ that complete the step must accept the same payload from that sender. Do not
 advance merely because a local node has received enough mutually inconsistent
 point-to-point copies.
 
+Protocol deserializers cap participant-sized collections at the largest count
+representable by a `u16`. This is a defense-in-depth limit, not a network frame
+limit: reject oversized byte frames before invoking Serde, because the input
+format and individual field encodings may allocate while decoding.
+
 ## Threshold signing
 
 The primary API is in the `shamir` module:
@@ -135,10 +140,30 @@ each logical signing attempt, and ensure every participant agrees on the same
 session ID, signer set, public key, and message. Secret-key shares and DKG or
 reshare polynomial evaluations must be stored and transported as secrets.
 
+### Side-channel limitations
+
+The Baby Jubjub implementation uses arkworks curve and field arithmetic. The
+arkworks 0.6 scalar-multiplication implementation is not guaranteed to be
+constant-time and includes secret-dependent control flow. Consequently, this
+crate must not be treated as resistant to local timing, cache, branch-trace,
+power, or similar side-channel attackers. Deploy it only where that threat is
+excluded or use a separately reviewed constant-time arithmetic backend.
+
 ## Distributed key generation
 
 `keygen::Parameters::new(n, t)` configures an `n`-party sharing whose polynomial
-degree is `t - 1`; any `t` resulting shares can sign.
+degree is `t - 1`; any `t` resulting shares can sign. Note that the source
+protocol document uses `t` for the polynomial _degree_ instead, so its `t` maps
+to `Parameters::new(n, t + 1)` here.
+
+Session IDs for key generation and resharing must be globally unique per run,
+not merely agreed. The session ID is the only run-specific input to the
+proof-of-possession context, so reusing it with the same parameters makes
+round-one broadcasts replayable: an adversary with network control can suppress
+an honest party's fresh broadcast, inject its stale one from the earlier run, and
+have that party's fresh private evaluations fail against the stale commitments —
+which gets an honest party blamed and disqualified. Use a fresh `Uuid::new_v4`
+per run and never derive the ID from configuration alone.
 
 1. Every party creates `keygen::round1::RoundOne` with identical parameters and
    session ID. It reliably broadcasts `get_broadcast_message()`, containing its
@@ -184,9 +209,13 @@ keeps a `pk_shares` entry and `finalize()` returns its share. Its ID is still
 listed in `BlameResult::disqualified_parties`; exclude a proven cheater from
 future signing committees at the application layer if that is the intent.
 Round-one disqualifications are different: those parties never reached round two,
-so they are not shareholders and hold nothing. Every disqualification API refuses
-the decision that would leave fewer than `t` parties, so a run can never silently
-produce an unusable key.
+so they are not shareholders and hold nothing. `disqualify_parties` and
+`disqualify_missing_verdict` refuse a decision that would leave fewer than `t`
+parties. `disqualify_missing_dealer` and the implicit disqualification of an
+invalid revelation do not: those are caught one step later, by `finalize`, which
+refuses to produce a key from fewer than `t` qualified dealers. Either way a run
+can never silently produce an unusable key, but check the count yourself if you
+want the failure attributed to the decision that caused it.
 
 If a selected dealer's private round-two evaluation never arrives, call
 `complain_missing_party` after an externally agreed delivery deadline, then
@@ -208,6 +237,16 @@ dealer set.
 Resharing replaces the Shamir sharing while preserving the secret key and
 public key. It can change `n`, change `t`, rotate participants, or refresh shares
 for the same configuration.
+
+> [!WARNING]
+> Resharing does not cryptographically revoke or erase the old shares. During
+> handover, both the old and new sharings authorize the same public key. After
+> every honest participant has durably committed to the same successful new
+> epoch, securely erase the old shares and make honest signers reject stale
+> epoch/session coordination. Epoch checks alone cannot stop an attacker that
+> has retained an old threshold. Proactive security across refreshes requires
+> secure erasure and fewer than the threshold shares being compromised in each
+> epoch; otherwise retained shares can accumulate across epochs.
 
 1. All participants first agree on identical old and new `Parameters`, the old
    public key, a fresh session ID, and a selected old-party sender set containing
@@ -254,8 +293,26 @@ it may already possess. At least the new threshold number of receivers must
 remain. The exclusion is reported in `BlameResult::excluded_verdict_parties`.
 
 Do not let each receiver choose its own sender set or independently decide which
-senders timed out. Doing so can create divergent shares and public-key-share
-metadata even when every local cryptographic check succeeds.
+senders timed out, and note that **the public-key check cannot detect a
+violation**. Resharing combines the surviving senders as
+`P_S(Z) = Σ_{i∈S} λ_i^S · f_i(Z)`; every Lagrange coefficient depends on the
+surviving set `S`, but `P_S(0)` is the signing key for _every_ valid `S`.
+Receivers that disagreed on `S` therefore hold points on unrelated polynomials
+while both reconstruct the correct public key, so `finalize` succeeds on both
+sides and the shares silently fail to interpolate. The DKG has no such blind
+spot: there a divergent dealer set changes the public key itself.
+
+Compare `Finished::agreement_digest()` across all receivers and treat any
+mismatch as a failed run **before** erasing the old shares. The digest covers the
+session ID, `contributing_parties`, `pk`, and `pk_shares` — everything that must
+agree — and excludes the per-party `my_idx` and `sk_share`. The surviving sender
+set is also reported directly as `Finished::contributing_parties`; for a reshare
+these are old-committee indices, whereas `pk_shares` is keyed by new-party index.
+
+In particular, the choice between `complain_missing_share` and
+`disqualify_missing_sender` must itself be an externally agreed decision: both
+are reachable whenever nothing has been recorded for a sender, and only the
+former keeps it in `S`.
 
 ## Outputs and interoperability
 
@@ -264,6 +321,37 @@ DKG and reshare return `keygen::finished::Finished<C>`. For Baby Jubjub, use
 `shamir::secret::DLogShareShamir` for signing by binding the share to its party
 ID, total party count, and threshold; `pk` and `pk_shares` supply the public
 values required for verification and identifiable abort.
+`contributing_parties` names the qualified dealers or surviving old senders, and
+`agreement_digest()` reduces every value that must agree across participants to
+one comparable 32-byte hash.
+
+There is deliberately no automatic conversion to `DLogShareShamir`, because
+`Finished` does not carry the run's `Parameters`. Supply the party count and
+threshold yourself, and take care: a wrong-but-self-consistent value is accepted
+silently. `sign_round` derives the Lagrange coefficient from the signer set, so a
+too-small threshold only loosens the minimum-signer-set check and a too-large
+party count only loosens the range check. Neither enables a forgery, but neither
+is caught either. After a reshare, pass the _new_ parameters.
+
+## Error attribution
+
+The message-intake APIs — `RoundOne::add_party_communication`,
+`RoundTwo::add_party_communication`, and the `ReShareProtocolReceiver` intake
+methods — return `keygen::MessageError`, which keeps three outcomes apart:
+
+- `MaliciousParty` and `DuplicateCommitments` **attribute blame**: a
+  cryptographic check failed and the named parties are provably at fault.
+- `Malformed` does not. The message did not fit the local protocol view, most
+  often because the _local_ node is misconfigured — a node started with different
+  `Parameters` derives a different proof-of-possession context and expects a
+  different commitment count, so every honest peer looks wrong to it.
+  Disqualifying on this basis would remove an honest participant.
+- `LocalFault` means the caller misused the API, so no remote message was
+  evaluated.
+
+Use `MessageError::attributable_parties()` to act on blame. Every variant names
+the parties involved in its `Display` output, so logging the error no longer
+discards the attribution — but only the first two justify a disqualification.
 
 The final threshold signature is an
 `eddsa_babyjubjub::EdDSASignature` and is verified exactly like a regular

--- a/threshold-eddsa-babyjubjub/src/additive/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/commit.rs
@@ -6,7 +6,7 @@
 //! that contributed a malformed share.
 
 use crate::{
-    Affine, BaseField, MaliciousPartiesError, Projective, ScalarField,
+    Affine, BaseField, IdentifiableAbortError, MaliciousPartiesError, Projective, ScalarField,
     additive::{partial_commit::PartialEdDSACommitmentsAdditive, signature::EdDSASigShareAdditive},
     commit::EdDSACommitments,
     nonce::CombineTwoNonceRandomnessArgs,
@@ -82,9 +82,12 @@ impl EdDSACommitmentsAdditive {
     /// Signature shares and nonce commitments carry party IDs. Public-key shares are keyed by ID.
     ///
     /// # Errors
-    /// Returns a [`MaliciousPartiesError`] with the IDs of all parties whose signature share does
-    /// not verify against their commitment and their share of the public key.
-    ///
+    /// Returns [`IdentifiableAbortError::MaliciousParties`] with the IDs of all parties whose
+    /// signature share does not verify against their commitment and their share of the public key.
+    /// Returns [`IdentifiableAbortError::InvalidInput`] when the supplied shares, commitments, or
+    /// public-key shares do not match the contributing party set, do not sum to the stored
+    /// aggregate, or do not reconstruct the public key — in that case no share was validated and no
+    /// participant may be accused.
     pub fn sign_agg_with_identifiable_abort(
         self,
         session_id: Uuid,
@@ -93,7 +96,7 @@ impl EdDSACommitmentsAdditive {
         public_key: &EdDSAPublicKey,
         x_share_commitments: &BTreeMap<u16, Affine>,
         commitments: &[PartialEdDSACommitmentsAdditive],
-    ) -> eyre::Result<EdDSASignature> {
+    ) -> Result<EdDSASignature, IdentifiableAbortError> {
         EdDSACommitments::validate_party_ids(&self.0.contributing_parties)?;
         let shares = self.ordered_shares(shares)?;
         let commitment_by_party = commitments
@@ -104,23 +107,23 @@ impl EdDSACommitmentsAdditive {
             || commitment_by_party.keys().copied().collect::<Vec<_>>()
                 != self.0.contributing_parties
         {
-            eyre::bail!("nonce commitments do not match the contributing party set");
+            return Err(eyre::eyre!("nonce commitments do not match the contributing party set").into());
         }
         if x_share_commitments.keys().copied().collect::<Vec<_>>() != self.0.contributing_parties {
-            eyre::bail!("public-key shares do not match the contributing party set");
+            return Err(eyre::eyre!("public-key shares do not match the contributing party set").into());
         }
         let (individual_d, individual_e) = commitment_by_party.values().fold(
             (Projective::zero(), Projective::zero()),
             |(d, e), commitment| (d + commitment.0.d, e + commitment.0.e),
         );
         if individual_d.into_affine() != self.0.d || individual_e.into_affine() != self.0.e {
-            eyre::bail!("individual and aggregate nonce commitments differ");
+            return Err(eyre::eyre!("individual and aggregate nonce commitments differ").into());
         }
         let reconstructed_pk = x_share_commitments
             .values()
             .fold(Projective::zero(), |acc, point| acc + point);
         if reconstructed_pk.into_affine() != public_key.pk {
-            eyre::bail!("public-key shares do not reconstruct the public key");
+            return Err(eyre::eyre!("public-key shares do not reconstruct the public key").into());
         }
 
         let (r, b) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
@@ -160,7 +163,7 @@ impl EdDSACommitmentsAdditive {
         }
 
         if !cheating_parties.is_empty() {
-            eyre::bail!(MaliciousPartiesError(cheating_parties));
+            return Err(MaliciousPartiesError(cheating_parties).into());
         }
 
         // Finally assemble the signature

--- a/threshold-eddsa-babyjubjub/src/additive/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/commit.rs
@@ -17,6 +17,7 @@ use ark_serialize::Valid;
 use eddsa_babyjubjub::{EdDSAPublicKey, EdDSASignature};
 use itertools::izip;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use uuid::Uuid;
 
 /// Commitment aggregation object for the additive `EdDSA` protocol.
@@ -30,21 +31,20 @@ pub struct EdDSACommitmentsAdditive(pub(crate) EdDSACommitments);
 impl EdDSACommitmentsAdditive {
     /// Create an aggregated commitment object from component affine points and party IDs.
     ///
-    /// # Panics
-    /// Panics if a commitment is invalid, or if party IDs are empty, zero, or duplicated.
-    #[must_use]
-    pub fn new(d: Affine, e: Affine, parties: Vec<u16>) -> Self {
-        assert!(
-            d.check().is_ok() && e.check().is_ok(),
-            "commitments must be valid subgroup points"
-        );
-        EdDSACommitments::validate_party_ids(&parties);
+    /// # Errors
+    /// Returns an error if a commitment is invalid, or if party IDs are empty, zero, duplicated,
+    /// or not canonically ordered.
+    pub fn new(d: Affine, e: Affine, parties: Vec<u16>) -> eyre::Result<Self> {
+        if d.check().is_err() || e.check().is_err() {
+            eyre::bail!("commitments must be valid subgroup points");
+        }
+        EdDSACommitments::validate_party_ids(&parties)?;
         let commitments = EdDSACommitments {
             d,
             e,
             contributing_parties: parties,
         };
-        Self(commitments)
+        Ok(Self(commitments))
     }
 
     /// Returns the parties that contributed to this commitment.
@@ -55,86 +55,73 @@ impl EdDSACommitmentsAdditive {
 
     /// Combine all parties' signature shares into a single `EdDSA` signature object.
     ///
-    /// Must use the same order of contributing parties as in aggregation
+    /// Signature shares are matched to the contributing set by their embedded party IDs.
     ///
-    /// # Panics
-    /// Panics unless exactly one signature share is supplied per contributing party.
-    #[must_use]
+    /// # Errors
+    /// Returns an error unless exactly one signature share is supplied for each contributing
+    /// party.
     pub fn sign_agg(
         self,
         session_id: Uuid,
         shares: &[EdDSASigShareAdditive],
         message: BaseField,
         public_key: EdDSAPublicKey,
-    ) -> EdDSASignature {
-        assert_eq!(
-            shares.len(),
-            self.0.contributing_parties.len(),
-            "one share is required per contributing party"
-        );
-        self.0
-            .sign_agg(session_id, shares.iter().map(|x| &x.0), message, public_key)
+    ) -> eyre::Result<EdDSASignature> {
+        let shares = self.ordered_shares(shares)?;
+        Ok(self.0.sign_agg(
+            session_id,
+            shares.into_iter().map(|share| &share.0),
+            message,
+            public_key,
+        ))
     }
 
     /// Combine all parties' signature shares into a single `EdDSA` signature object, verifying
     /// each party's contribution individually so that malformed shares can be attributed.
     ///
-    /// The shares, commitments, and `x_share_commitments` must be in canonical order.
+    /// Signature shares and nonce commitments carry party IDs. Public-key shares are keyed by ID.
     ///
     /// # Errors
     /// Returns a [`MaliciousPartiesError`] with the IDs of all parties whose signature share does
     /// not verify against their commitment and their share of the public key.
     ///
-    /// # Panics
-    /// Panics if `shares`, `x_share_commitments` and `commitments` do not all have the same length.
-    /// The call site is expected to enforce this.
     pub fn sign_agg_with_identifiable_abort(
         self,
         session_id: Uuid,
         shares: &[EdDSASigShareAdditive],
         message: BaseField,
         public_key: &EdDSAPublicKey,
-        x_share_commitments: &[Affine],
+        x_share_commitments: &BTreeMap<u16, Affine>,
         commitments: &[PartialEdDSACommitmentsAdditive],
-    ) -> Result<EdDSASignature, MaliciousPartiesError> {
-        assert_eq!(
-            shares.len(),
-            x_share_commitments.len(),
-            "Shares and commitments must match"
-        );
-        assert_eq!(
-            shares.len(),
-            self.0.contributing_parties.len(),
-            "one share is required per contributing party"
-        );
-        EdDSACommitments::validate_party_ids(&self.0.contributing_parties);
-        let (individual_d, individual_e) = commitments.iter().fold(
+    ) -> eyre::Result<EdDSASignature> {
+        EdDSACommitments::validate_party_ids(&self.0.contributing_parties)?;
+        let shares = self.ordered_shares(shares)?;
+        let commitment_by_party = commitments
+            .iter()
+            .map(|commitment| (commitment.party_id(), commitment))
+            .collect::<BTreeMap<_, _>>();
+        if commitment_by_party.len() != commitments.len()
+            || commitment_by_party.keys().copied().collect::<Vec<_>>()
+                != self.0.contributing_parties
+        {
+            eyre::bail!("nonce commitments do not match the contributing party set");
+        }
+        if x_share_commitments.keys().copied().collect::<Vec<_>>() != self.0.contributing_parties {
+            eyre::bail!("public-key shares do not match the contributing party set");
+        }
+        let (individual_d, individual_e) = commitment_by_party.values().fold(
             (Projective::zero(), Projective::zero()),
             |(d, e), commitment| (d + commitment.0.d, e + commitment.0.e),
         );
-        assert_eq!(
-            individual_d.into_affine(),
-            self.0.d,
-            "individual and aggregate d commitments differ"
-        );
-        assert_eq!(
-            individual_e.into_affine(),
-            self.0.e,
-            "individual and aggregate e commitments differ"
-        );
+        if individual_d.into_affine() != self.0.d || individual_e.into_affine() != self.0.e {
+            eyre::bail!("individual and aggregate nonce commitments differ");
+        }
         let reconstructed_pk = x_share_commitments
-            .iter()
+            .values()
             .fold(Projective::zero(), |acc, point| acc + point);
-        assert_eq!(
-            reconstructed_pk.into_affine(),
-            public_key.pk,
-            "public-key shares do not reconstruct the public key"
-        );
-        assert_eq!(
-            shares.len(),
-            commitments.len(),
-            "Shares and commitments must match"
-        );
+        if reconstructed_pk.into_affine() != public_key.pk {
+            eyre::bail!("public-key shares do not reconstruct the public key");
+        }
 
         let (r, b) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
             session_id,
@@ -153,10 +140,14 @@ impl EdDSACommitmentsAdditive {
 
         // For identifiable abort, we check the contribution of all parties
         let mut cheating_parties = Vec::new();
-        for (id, (share, x_share_commitment, commitment)) in
-            izip!(shares, x_share_commitments, commitments).enumerate()
+        for (id, (share, x_share_commitment, commitment)) in izip!(
+            &shares,
+            x_share_commitments.values(),
+            commitment_by_party.values()
+        )
+        .enumerate()
         {
-            let s = share.0.0;
+            let s = share.0.1;
             let r = commitment.0.d + commitment.0.e * b;
             if !crate::commit::verify_for_identifiable_abort(
                 x_share_commitment,
@@ -169,13 +160,13 @@ impl EdDSACommitmentsAdditive {
         }
 
         if !cheating_parties.is_empty() {
-            return Err(MaliciousPartiesError(cheating_parties));
+            eyre::bail!(MaliciousPartiesError(cheating_parties));
         }
 
         // Finally assemble the signature
         let mut s = ScalarField::zero();
         for share in shares {
-            s += share.0.0;
+            s += share.0.1;
         }
 
         let sig = EdDSASignature { r, s };
@@ -184,10 +175,20 @@ impl EdDSACommitmentsAdditive {
 
     /// The accumulating party (i.e., the aggregatir) combines the shares of `n` parties.
     /// The returned points are the combined commitments C, R.
-    #[must_use]
-    pub fn pre_agg(commitments: &[(u16, PartialEdDSACommitmentsAdditive)]) -> Self {
-        let party_ids = commitments.iter().map(|(id, _)| *id).collect::<Vec<_>>();
-        EdDSACommitments::validate_party_ids(&party_ids);
+    ///
+    /// # Errors
+    /// Returns an error for an empty set or duplicate/invalid party IDs.
+    pub fn pre_agg(commitments: &[PartialEdDSACommitmentsAdditive]) -> eyre::Result<Self> {
+        let input_len = commitments.len();
+        let commitments = commitments
+            .iter()
+            .map(|commitment| (commitment.party_id(), commitment))
+            .collect::<BTreeMap<_, _>>();
+        if commitments.len() != input_len {
+            eyre::bail!("duplicate nonce commitment party ID");
+        }
+        let party_ids = commitments.keys().copied().collect::<Vec<_>>();
+        EdDSACommitments::validate_party_ids(&party_ids)?;
         let mut d = Projective::zero();
         let mut e = Projective::zero();
         let mut contributing_parties = Vec::with_capacity(commitments.len());
@@ -195,7 +196,7 @@ impl EdDSACommitmentsAdditive {
         for (party_id, PartialEdDSACommitmentsAdditive(comm)) in commitments {
             d += comm.d;
             e += comm.e;
-            contributing_parties.push(*party_id);
+            contributing_parties.push(party_id);
         }
 
         let d = d.into_affine();
@@ -206,6 +207,22 @@ impl EdDSACommitmentsAdditive {
             e,
             contributing_parties,
         };
-        EdDSACommitmentsAdditive(commitments)
+        Ok(EdDSACommitmentsAdditive(commitments))
+    }
+
+    fn ordered_shares<'a>(
+        &self,
+        shares: &'a [EdDSASigShareAdditive],
+    ) -> eyre::Result<Vec<&'a EdDSASigShareAdditive>> {
+        let shares = shares
+            .iter()
+            .map(|share| (share.party_id(), share))
+            .collect::<BTreeMap<_, _>>();
+        if shares.len() != self.0.contributing_parties.len()
+            || shares.keys().copied().collect::<Vec<_>>() != self.0.contributing_parties
+        {
+            eyre::bail!("signature shares do not match the contributing party set");
+        }
+        Ok(shares.into_values().collect())
     }
 }

--- a/threshold-eddsa-babyjubjub/src/additive/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/commit.rs
@@ -1,0 +1,164 @@
+//! Aggregated commitments for the additive threshold `EdDSA` protocol.
+//!
+//! This module defines the `EdDSACommitmentsAdditive` struct, which sums the per-party commitment
+//! shares of all `n` parties and combines the received signature shares into the final `EdDSA`
+//! signature. It also offers an aggregation with identifiable abort, which pinpoints the parties
+//! that contributed a malformed share.
+
+use crate::{
+    Affine, BaseField, CheatingPartiesError, Projective, ScalarField,
+    additive::{partial_commit::PartialEdDSACommitmentsAdditive, signature::EdDSASigShareAdditive},
+    commit::EdDSACommitments,
+    nonce::CombineTwoNonceRandomnessArgs,
+};
+use ark_ec::CurveGroup;
+use ark_ff::Zero;
+use eddsa_babyjubjub::{EdDSAPublicKey, EdDSASignature};
+use itertools::izip;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Commitment aggregation object for the additive `EdDSA` protocol.
+///
+/// Transparent wrapper for individual commitment shares produced by each participant in the additive
+/// secret sharing case, ready for simple sum aggregation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EdDSACommitmentsAdditive(pub(crate) EdDSACommitments);
+
+impl EdDSACommitmentsAdditive {
+    /// Create an aggregated commitment object from component affine points and party IDs.
+    #[must_use]
+    pub fn new(d: Affine, e: Affine, parties: Vec<u16>) -> Self {
+        let commitments = EdDSACommitments {
+            d,
+            e,
+            contributing_parties: parties,
+        };
+        Self(commitments)
+    }
+
+    /// Returns the parties that contributed to this commitment.
+    #[must_use]
+    pub fn get_contributing_parties(&self) -> &[u16] {
+        &self.0.contributing_parties
+    }
+
+    /// Combine all parties' signature shares into a single `EdDSA` signature object.
+    ///
+    /// Must use the same order of contributing parties as in aggregation
+    #[must_use]
+    pub fn sign_agg(
+        self,
+        session_id: Uuid,
+        shares: &[EdDSASigShareAdditive],
+        message: BaseField,
+        public_key: EdDSAPublicKey,
+    ) -> EdDSASignature {
+        self.0
+            .sign_agg(session_id, shares.iter().map(|x| &x.0), message, public_key)
+    }
+
+    /// Combine all parties' signature shares into a single `EdDSA` signature object, verifying
+    /// each party's contribution individually so that malformed shares can be attributed.
+    ///
+    /// The shares, commitments, and `x_share_commitments` must be in canonical order.
+    ///
+    /// # Errors
+    /// Returns a [`CheatingPartiesError`] with the IDs of all parties whose signature share does
+    /// not verify against their commitment and their share of the public key.
+    ///
+    /// # Panics
+    /// Panics if `shares`, `x_share_commitments` and `commitments` do not all have the same length.
+    /// The call site is expected to enforce this.
+    pub fn sign_agg_with_identifiable_abort(
+        self,
+        session_id: Uuid,
+        shares: &[EdDSASigShareAdditive],
+        message: BaseField,
+        public_key: &EdDSAPublicKey,
+        x_share_commitments: &[Affine],
+        commitments: &[PartialEdDSACommitmentsAdditive],
+    ) -> Result<EdDSASignature, CheatingPartiesError> {
+        assert_eq!(
+            shares.len(),
+            x_share_commitments.len(),
+            "Shares and commitments must match"
+        );
+        assert_eq!(
+            shares.len(),
+            commitments.len(),
+            "Shares and commitments must match"
+        );
+
+        let (r, b) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
+            session_id,
+            message,
+            public_key: public_key.clone(),
+            d: self.0.d,
+            e: self.0.e,
+            parties: &self.0.contributing_parties,
+        });
+
+        // Recompute the challenge hash to ensure the challenge is well-formed.
+        let c = eddsa_babyjubjub::challenge_hash(message, r, public_key.pk);
+
+        // The following modular reduction in convert_base_to_scalar is required in rust to perform the scalar multiplications. Using all 254 bits of the base field in a double/add ladder would apply this reduction implicitly. We show in the docs of convert_base_to_scalar why this does not introduce a bias when applied to a uniform element of the base field.
+        let c_ = eddsa_babyjubjub::convert_base_to_scalar(c);
+
+        // For identifiable abort, we check the contribution of all parties
+        let mut cheating_parties = Vec::new();
+        for (id, (share, x_share_commitment, commitment)) in
+            izip!(shares, x_share_commitments, commitments).enumerate()
+        {
+            let s = share.0.0;
+            let r = commitment.0.d + commitment.0.e * b;
+            if !crate::commit::verify_for_identifiable_abort(
+                x_share_commitment,
+                r.into_affine(),
+                s,
+                c_,
+            ) {
+                cheating_parties.push(id + 1);
+            }
+        }
+
+        if !cheating_parties.is_empty() {
+            return Err(CheatingPartiesError(cheating_parties));
+        }
+
+        // Finally assemble the signature
+        let mut s = ScalarField::zero();
+        for share in shares {
+            s += share.0.0;
+        }
+
+        let sig = EdDSASignature { r, s };
+        Ok(sig)
+    }
+
+    /// The accumulating party (i.e., the aggregatir) combines the shares of `n` parties.
+    /// The returned points are the combined commitments C, R.
+    #[must_use]
+    pub fn pre_agg(commitments: &[(u16, PartialEdDSACommitmentsAdditive)]) -> Self {
+        let mut d = Projective::zero();
+        let mut e = Projective::zero();
+        let mut contributing_parties = Vec::with_capacity(commitments.len());
+
+        for (party_id, PartialEdDSACommitmentsAdditive(comm)) in commitments {
+            d += comm.d;
+            e += comm.e;
+            contributing_parties.push(*party_id);
+        }
+
+        let d = d.into_affine();
+        let e = e.into_affine();
+
+        let commitments = EdDSACommitments {
+            d,
+            e,
+            contributing_parties,
+        };
+        EdDSACommitmentsAdditive(commitments)
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/additive/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/commit.rs
@@ -107,10 +107,14 @@ impl EdDSACommitmentsAdditive {
             || commitment_by_party.keys().copied().collect::<Vec<_>>()
                 != self.0.contributing_parties
         {
-            return Err(eyre::eyre!("nonce commitments do not match the contributing party set").into());
+            return Err(
+                eyre::eyre!("nonce commitments do not match the contributing party set").into(),
+            );
         }
         if x_share_commitments.keys().copied().collect::<Vec<_>>() != self.0.contributing_parties {
-            return Err(eyre::eyre!("public-key shares do not match the contributing party set").into());
+            return Err(
+                eyre::eyre!("public-key shares do not match the contributing party set").into(),
+            );
         }
         let (individual_d, individual_e) = commitment_by_party.values().fold(
             (Projective::zero(), Projective::zero()),
@@ -178,6 +182,9 @@ impl EdDSACommitmentsAdditive {
 
     /// The accumulating party (i.e., the aggregatir) combines the shares of `n` parties.
     /// The returned points are the combined commitments C, R.
+    ///
+    /// As in [`EdDSACommitmentsShamir::pre_agg`](crate::shamir::commit::EdDSACommitmentsShamir::pre_agg),
+    /// duplicate party IDs are rejected but duplicate `(d, e)` pairs are not.
     ///
     /// # Errors
     /// Returns an error for an empty set or duplicate/invalid party IDs.

--- a/threshold-eddsa-babyjubjub/src/additive/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/commit.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use ark_ec::CurveGroup;
 use ark_ff::Zero;
+use ark_serialize::Valid;
 use eddsa_babyjubjub::{EdDSAPublicKey, EdDSASignature};
 use itertools::izip;
 use serde::{Deserialize, Serialize};
@@ -28,8 +29,16 @@ pub struct EdDSACommitmentsAdditive(pub(crate) EdDSACommitments);
 
 impl EdDSACommitmentsAdditive {
     /// Create an aggregated commitment object from component affine points and party IDs.
+    ///
+    /// # Panics
+    /// Panics if a commitment is invalid, or if party IDs are empty, zero, or duplicated.
     #[must_use]
     pub fn new(d: Affine, e: Affine, parties: Vec<u16>) -> Self {
+        assert!(
+            d.check().is_ok() && e.check().is_ok(),
+            "commitments must be valid subgroup points"
+        );
+        EdDSACommitments::validate_party_ids(&parties);
         let commitments = EdDSACommitments {
             d,
             e,
@@ -47,6 +56,9 @@ impl EdDSACommitmentsAdditive {
     /// Combine all parties' signature shares into a single `EdDSA` signature object.
     ///
     /// Must use the same order of contributing parties as in aggregation
+    ///
+    /// # Panics
+    /// Panics unless exactly one signature share is supplied per contributing party.
     #[must_use]
     pub fn sign_agg(
         self,
@@ -55,6 +67,11 @@ impl EdDSACommitmentsAdditive {
         message: BaseField,
         public_key: EdDSAPublicKey,
     ) -> EdDSASignature {
+        assert_eq!(
+            shares.len(),
+            self.0.contributing_parties.len(),
+            "one share is required per contributing party"
+        );
         self.0
             .sign_agg(session_id, shares.iter().map(|x| &x.0), message, public_key)
     }
@@ -84,6 +101,34 @@ impl EdDSACommitmentsAdditive {
             shares.len(),
             x_share_commitments.len(),
             "Shares and commitments must match"
+        );
+        assert_eq!(
+            shares.len(),
+            self.0.contributing_parties.len(),
+            "one share is required per contributing party"
+        );
+        EdDSACommitments::validate_party_ids(&self.0.contributing_parties);
+        let (individual_d, individual_e) = commitments.iter().fold(
+            (Projective::zero(), Projective::zero()),
+            |(d, e), commitment| (d + commitment.0.d, e + commitment.0.e),
+        );
+        assert_eq!(
+            individual_d.into_affine(),
+            self.0.d,
+            "individual and aggregate d commitments differ"
+        );
+        assert_eq!(
+            individual_e.into_affine(),
+            self.0.e,
+            "individual and aggregate e commitments differ"
+        );
+        let reconstructed_pk = x_share_commitments
+            .iter()
+            .fold(Projective::zero(), |acc, point| acc + point);
+        assert_eq!(
+            reconstructed_pk.into_affine(),
+            public_key.pk,
+            "public-key shares do not reconstruct the public key"
         );
         assert_eq!(
             shares.len(),
@@ -119,7 +164,7 @@ impl EdDSACommitmentsAdditive {
                 s,
                 c_,
             ) {
-                cheating_parties.push(id + 1);
+                cheating_parties.push(usize::from(self.0.contributing_parties[id]));
             }
         }
 
@@ -141,6 +186,8 @@ impl EdDSACommitmentsAdditive {
     /// The returned points are the combined commitments C, R.
     #[must_use]
     pub fn pre_agg(commitments: &[(u16, PartialEdDSACommitmentsAdditive)]) -> Self {
+        let party_ids = commitments.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+        EdDSACommitments::validate_party_ids(&party_ids);
         let mut d = Projective::zero();
         let mut e = Projective::zero();
         let mut contributing_parties = Vec::with_capacity(commitments.len());

--- a/threshold-eddsa-babyjubjub/src/additive/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/commit.rs
@@ -6,7 +6,7 @@
 //! that contributed a malformed share.
 
 use crate::{
-    Affine, BaseField, CheatingPartiesError, Projective, ScalarField,
+    Affine, BaseField, MaliciousPartiesError, Projective, ScalarField,
     additive::{partial_commit::PartialEdDSACommitmentsAdditive, signature::EdDSASigShareAdditive},
     commit::EdDSACommitments,
     nonce::CombineTwoNonceRandomnessArgs,
@@ -65,7 +65,7 @@ impl EdDSACommitmentsAdditive {
     /// The shares, commitments, and `x_share_commitments` must be in canonical order.
     ///
     /// # Errors
-    /// Returns a [`CheatingPartiesError`] with the IDs of all parties whose signature share does
+    /// Returns a [`MaliciousPartiesError`] with the IDs of all parties whose signature share does
     /// not verify against their commitment and their share of the public key.
     ///
     /// # Panics
@@ -79,7 +79,7 @@ impl EdDSACommitmentsAdditive {
         public_key: &EdDSAPublicKey,
         x_share_commitments: &[Affine],
         commitments: &[PartialEdDSACommitmentsAdditive],
-    ) -> Result<EdDSASignature, CheatingPartiesError> {
+    ) -> Result<EdDSASignature, MaliciousPartiesError> {
         assert_eq!(
             shares.len(),
             x_share_commitments.len(),
@@ -124,7 +124,7 @@ impl EdDSACommitmentsAdditive {
         }
 
         if !cheating_parties.is_empty() {
-            return Err(CheatingPartiesError(cheating_parties));
+            return Err(MaliciousPartiesError(cheating_parties));
         }
 
         // Finally assemble the signature

--- a/threshold-eddsa-babyjubjub/src/additive/mod.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/mod.rs
@@ -1,0 +1,15 @@
+//! Threshold `EdDSA` with additive secret sharing.
+//!
+//! This module implements the `n`-out-of-`n` variant of the protocol, where the signing key is
+//! split into shares that sum to it, so every party has to contribute to a signature.
+//!
+//! The types defined in the submodules are thin wrappers around the scheme-agnostic primitives in
+//! the crate root modules `commit`, `nonce`, `partial_commit`, `session` and `signature`.
+
+pub mod commit;
+pub mod partial_commit;
+pub mod secret;
+pub mod session;
+pub mod signature;
+#[cfg(test)]
+pub mod test;

--- a/threshold-eddsa-babyjubjub/src/additive/partial_commit.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/partial_commit.rs
@@ -1,0 +1,16 @@
+//! Per-party commitments for the additive threshold `EdDSA` protocol.
+//!
+//! This module defines the `PartialEdDSACommitmentsAdditive` struct, the commitment share a single
+//! party sends to the aggregator in the pre-round.
+
+use crate::partial_commit::PartialEdDSACommitments;
+use serde::{Deserialize, Serialize};
+
+/// Per-party commitment shares for the additive `EdDSA` protocol.
+///
+/// Wraps and serializes individual party commitments to the distributed `EdDSA` signature,
+/// in the context of additive secret sharing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[repr(transparent)]
+#[serde(transparent)]
+pub struct PartialEdDSACommitmentsAdditive(pub(crate) PartialEdDSACommitments);

--- a/threshold-eddsa-babyjubjub/src/additive/partial_commit.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/partial_commit.rs
@@ -14,3 +14,11 @@ use serde::{Deserialize, Serialize};
 #[repr(transparent)]
 #[serde(transparent)]
 pub struct PartialEdDSACommitmentsAdditive(pub(crate) PartialEdDSACommitments);
+
+impl PartialEdDSACommitmentsAdditive {
+    /// Return the party ID carried by this commitment.
+    #[must_use]
+    pub fn party_id(&self) -> u16 {
+        self.0.party_id()
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/additive/secret.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/secret.rs
@@ -14,9 +14,7 @@ use zeroize::ZeroizeOnDrop;
 /// Serializable so it can be persisted via a secret manager.
 /// Not `Debug`/`Display` to avoid accidental leaks.
 ///
-#[derive(
-    Clone, Serialize, Deserialize, ZeroizeOnDrop, CanonicalSerialize, CanonicalDeserialize,
-)]
+#[derive(Serialize, Deserialize, ZeroizeOnDrop, CanonicalSerialize, CanonicalDeserialize)]
 #[serde(transparent)]
 pub struct DLogShareAdditive(#[serde(with = "ark_serde_compat::field")] pub(crate) ScalarField);
 

--- a/threshold-eddsa-babyjubjub/src/additive/secret.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/secret.rs
@@ -3,44 +3,112 @@
 //! This module defines the `DLogShareAdditive` struct, one party's additive share of the discrete
 //! logarithm of the public key. All `n` shares sum to the signing key.
 
-use crate::ScalarField;
-use ark_serialize::CanonicalDeserialize;
-use ark_serialize::CanonicalSerialize;
-use serde::{Deserialize, Serialize};
+use crate::{Affine, ScalarField};
+use ark_ec::AffineRepr;
+use ark_serde_compat::babyjubjub;
+use ark_serialize::Valid;
+use eddsa_babyjubjub::EdDSAPublicKey;
+use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
 use zeroize::ZeroizeOnDrop;
 
 /// Additive Secret-share of an `EdDSA` signing secret.
 ///
+/// The scalar is bound to the identity, party count, and public key it belongs to, so
+/// [`sign_round`](crate::additive::session::EdDSASessionAdditive::sign_round) can check every one of
+/// them instead of trusting a caller-supplied argument. Deserialization enforces the same invariants
+/// as [`DLogShareAdditive::new`].
+///
 /// Serializable so it can be persisted via a secret manager.
 /// Not `Debug`/`Display` to avoid accidental leaks.
-///
-#[derive(Serialize, Deserialize, ZeroizeOnDrop, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Serialize, ZeroizeOnDrop)]
 pub struct DLogShareAdditive {
     #[serde(with = "ark_serde_compat::field")]
     pub(crate) value: ScalarField,
+    #[serde(with = "babyjubjub::affine")]
+    #[zeroize(skip)]
+    pub(crate) public_key: Affine,
     pub(crate) party_id: u16,
     pub(crate) number_of_parties: u16,
 }
 
 impl DLogShareAdditive {
-    /// Bind an additive scalar share to its identity and complete party count.
+    /// Bind an additive scalar share to its identity, complete party count, and public key.
     ///
     /// # Errors
-    /// Returns an error unless `1 <= party_id <= number_of_parties`.
-    pub fn new(value: ScalarField, party_id: u16, number_of_parties: u16) -> eyre::Result<Self> {
-        if party_id == 0 || number_of_parties == 0 || party_id > number_of_parties {
-            eyre::bail!("party ID must lie in the non-empty additive party set");
-        }
+    /// Returns an error unless `1 <= party_id <= number_of_parties` and `public_key` is a non-zero
+    /// point in the prime-order subgroup.
+    pub fn new(
+        value: ScalarField,
+        public_key: &EdDSAPublicKey,
+        party_id: u16,
+        number_of_parties: u16,
+    ) -> eyre::Result<Self> {
+        Self::validate(&public_key.pk, party_id, number_of_parties)?;
         Ok(Self {
             value,
+            public_key: public_key.pk,
             party_id,
             number_of_parties,
         })
+    }
+
+    fn validate(public_key: &Affine, party_id: u16, number_of_parties: u16) -> eyre::Result<()> {
+        if party_id == 0 || number_of_parties == 0 || party_id > number_of_parties {
+            eyre::bail!("party ID must lie in the non-empty additive party set");
+        }
+        if public_key.is_zero() || public_key.check().is_err() {
+            eyre::bail!("public key must be a non-zero point in the prime-order subgroup");
+        }
+        Ok(())
     }
 
     /// Return the identity bound to this share.
     #[must_use]
     pub fn party_id(&self) -> u16 {
         self.party_id
+    }
+
+    /// Return the public key this share belongs to.
+    #[must_use]
+    pub fn public_key(&self) -> EdDSAPublicKey {
+        EdDSAPublicKey {
+            pk: self.public_key,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for DLogShareAdditive {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Repr {
+            #[serde(with = "ark_serde_compat::field")]
+            value: ScalarField,
+            #[serde(with = "babyjubjub::affine")]
+            public_key: Affine,
+            party_id: u16,
+            number_of_parties: u16,
+        }
+
+        // The intermediate representation holds the secret scalar, so clear it rather than leaving a
+        // copy in freed memory. Every field is `Copy`, so reading them out below still works.
+        impl Drop for Repr {
+            fn drop(&mut self) {
+                use zeroize::Zeroize as _;
+                self.value.zeroize();
+            }
+        }
+
+        let repr = Repr::deserialize(deserializer)?;
+        DLogShareAdditive::validate(&repr.public_key, repr.party_id, repr.number_of_parties)
+            .map_err(D::Error::custom)?;
+        Ok(Self {
+            value: repr.value,
+            public_key: repr.public_key,
+            party_id: repr.party_id,
+            number_of_parties: repr.number_of_parties,
+        })
     }
 }

--- a/threshold-eddsa-babyjubjub/src/additive/secret.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/secret.rs
@@ -1,0 +1,33 @@
+//! Additive shares of the `EdDSA` signing key.
+//!
+//! This module defines the `DLogShareAdditive` struct, one party's additive share of the discrete
+//! logarithm of the public key. All `n` shares sum to the signing key.
+
+use crate::ScalarField;
+use ark_serialize::CanonicalDeserialize;
+use ark_serialize::CanonicalSerialize;
+use serde::{Deserialize, Serialize};
+use zeroize::ZeroizeOnDrop;
+
+/// Additive Secret-share of an `EdDSA` signing secret.
+///
+/// Serializable so it can be persisted via a secret manager.
+/// Not `Debug`/`Display` to avoid accidental leaks.
+///
+#[derive(
+    Clone, Serialize, Deserialize, ZeroizeOnDrop, CanonicalSerialize, CanonicalDeserialize,
+)]
+#[serde(transparent)]
+pub struct DLogShareAdditive(#[serde(with = "ark_serde_compat::field")] pub(crate) ScalarField);
+
+impl From<ark_babyjubjub::Fr> for DLogShareAdditive {
+    fn from(value: ark_babyjubjub::Fr) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DLogShareAdditive> for ark_babyjubjub::Fr {
+    fn from(value: DLogShareAdditive) -> Self {
+        value.0
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/additive/secret.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/secret.rs
@@ -15,17 +15,32 @@ use zeroize::ZeroizeOnDrop;
 /// Not `Debug`/`Display` to avoid accidental leaks.
 ///
 #[derive(Serialize, Deserialize, ZeroizeOnDrop, CanonicalSerialize, CanonicalDeserialize)]
-#[serde(transparent)]
-pub struct DLogShareAdditive(#[serde(with = "ark_serde_compat::field")] pub(crate) ScalarField);
-
-impl From<ark_babyjubjub::Fr> for DLogShareAdditive {
-    fn from(value: ark_babyjubjub::Fr) -> Self {
-        Self(value)
-    }
+pub struct DLogShareAdditive {
+    #[serde(with = "ark_serde_compat::field")]
+    pub(crate) value: ScalarField,
+    pub(crate) party_id: u16,
+    pub(crate) number_of_parties: u16,
 }
 
-impl From<DLogShareAdditive> for ark_babyjubjub::Fr {
-    fn from(value: DLogShareAdditive) -> Self {
-        value.0
+impl DLogShareAdditive {
+    /// Bind an additive scalar share to its identity and complete party count.
+    ///
+    /// # Errors
+    /// Returns an error unless `1 <= party_id <= number_of_parties`.
+    pub fn new(value: ScalarField, party_id: u16, number_of_parties: u16) -> eyre::Result<Self> {
+        if party_id == 0 || number_of_parties == 0 || party_id > number_of_parties {
+            eyre::bail!("party ID must lie in the non-empty additive party set");
+        }
+        Ok(Self {
+            value,
+            party_id,
+            number_of_parties,
+        })
+    }
+
+    /// Return the identity bound to this share.
+    #[must_use]
+    pub fn party_id(&self) -> u16 {
+        self.party_id
     }
 }

--- a/threshold-eddsa-babyjubjub/src/additive/session.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/session.rs
@@ -1,0 +1,67 @@
+//! Per-party session state for the additive threshold `EdDSA` protocol.
+//!
+//! This module defines the `EdDSASessionAdditive` struct, which holds the secret two-nonce
+//! randomness of one party between the pre-round and the signing round.
+//!
+//! Secret randomness is never clonable, and session types deliberately do not implement `Debug` to avoid accidental leakage.
+
+use crate::{
+    BaseField,
+    additive::{
+        commit::EdDSACommitmentsAdditive, partial_commit::PartialEdDSACommitmentsAdditive,
+        secret::DLogShareAdditive, signature::EdDSASigShareAdditive,
+    },
+    nonce::CombineTwoNonceRandomnessArgs,
+    session::EdDSASession,
+    signature::EdDSASigShare,
+};
+use eddsa_babyjubjub::EdDSAPublicKey;
+use rand::{CryptoRng, Rng};
+use uuid::Uuid;
+use zeroize::ZeroizeOnDrop;
+
+/// Wrapper for the internal `EdDSA` session state in the additive-sharing variant.
+///
+/// Stores non-clonable, non-debug secret state for a threshold party during the `EdDSA` protocol.
+/// Used to generate the commitment shares and construct the signature share for Shamir secret sharing.
+#[derive(ZeroizeOnDrop)]
+pub struct EdDSASessionAdditive(EdDSASession);
+
+impl EdDSASessionAdditive {
+    /// Computes commitments to two random values `d_share` and `e_share`, which will be the shares of the randomness used in the `EdDSA` signature.
+    /// The result is meant to be sent to one accumulating party (i.e., the aggregator) who combines all the shares of all parties and creates the challenge hash.
+    pub fn pre_round(rng: &mut (impl CryptoRng + Rng)) -> (Self, PartialEdDSACommitmentsAdditive) {
+        let (session, comm) = EdDSASession::pre_round(rng);
+        (Self(session), PartialEdDSACommitmentsAdditive(comm))
+    }
+
+    /// Finalizes a signature share for a given challenge hash and session.
+    /// The session and information therein is consumed to prevent reuse of the randomness.
+    #[must_use]
+    pub fn sign_round(
+        self,
+        session_id: Uuid,
+        DLogShareAdditive(x_share): DLogShareAdditive,
+        message: BaseField,
+        public_key: &EdDSAPublicKey,
+        EdDSACommitmentsAdditive(challenge_input): EdDSACommitmentsAdditive,
+    ) -> EdDSASigShareAdditive {
+        // Recombine the two-nonce randomness shares into the full randomness used in the challenge.
+        let (r, b) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
+            session_id,
+            message,
+            public_key: public_key.clone(),
+            d: challenge_input.d,
+            e: challenge_input.e,
+            parties: &challenge_input.contributing_parties,
+        });
+
+        // Recompute the challenge hash to ensure the challenge is well-formed.
+        let c = eddsa_babyjubjub::challenge_hash(message, r, public_key.pk);
+
+        // The following modular reduction in convert_base_to_scalar is required in rust to perform the scalar multiplications. Using all 254 bits of the base field in a double/add ladder would apply this reduction implicitly. We show in the docs of convert_base_to_scalar why this does not introduce a bias when applied to a uniform element of the base field.
+        let c_ = eddsa_babyjubjub::convert_base_to_scalar(c);
+        let share = EdDSASigShare(self.0.d + b * self.0.e + c_ * x_share);
+        EdDSASigShareAdditive(share)
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/additive/session.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/session.rs
@@ -41,7 +41,7 @@ impl EdDSASessionAdditive {
     pub fn sign_round(
         self,
         session_id: Uuid,
-        DLogShareAdditive(x_share): DLogShareAdditive,
+        x_share: &DLogShareAdditive,
         message: BaseField,
         public_key: &EdDSAPublicKey,
         EdDSACommitmentsAdditive(challenge_input): EdDSACommitmentsAdditive,
@@ -61,7 +61,7 @@ impl EdDSASessionAdditive {
 
         // The following modular reduction in convert_base_to_scalar is required in rust to perform the scalar multiplications. Using all 254 bits of the base field in a double/add ladder would apply this reduction implicitly. We show in the docs of convert_base_to_scalar why this does not introduce a bias when applied to a uniform element of the base field.
         let c_ = eddsa_babyjubjub::convert_base_to_scalar(c);
-        let share = EdDSASigShare(self.0.d + b * self.0.e + c_ * x_share);
+        let share = EdDSASigShare(self.0.d + b * self.0.e + c_ * x_share.0);
         EdDSASigShareAdditive(share)
     }
 }

--- a/threshold-eddsa-babyjubjub/src/additive/session.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/session.rs
@@ -30,14 +30,23 @@ pub struct EdDSASessionAdditive(EdDSASession);
 impl EdDSASessionAdditive {
     /// Computes commitments to two random values `d_share` and `e_share`, which will be the shares of the randomness used in the `EdDSA` signature.
     /// The result is meant to be sent to one accumulating party (i.e., the aggregator) who combines all the shares of all parties and creates the challenge hash.
-    pub fn pre_round(rng: &mut (impl CryptoRng + Rng)) -> (Self, PartialEdDSACommitmentsAdditive) {
-        let (session, comm) = EdDSASession::pre_round(rng);
-        (Self(session), PartialEdDSACommitmentsAdditive(comm))
+    ///
+    /// # Errors
+    /// Returns an error if `party_id` is zero.
+    pub fn pre_round(
+        party_id: u16,
+        rng: &mut (impl CryptoRng + Rng),
+    ) -> eyre::Result<(Self, PartialEdDSACommitmentsAdditive)> {
+        let (session, comm) = EdDSASession::pre_round(party_id, rng)?;
+        Ok((Self(session), PartialEdDSACommitmentsAdditive(comm)))
     }
 
     /// Finalizes a signature share for a given challenge hash and session.
     /// The session and information therein is consumed to prevent reuse of the randomness.
-    #[must_use]
+    ///
+    /// # Errors
+    /// Returns an error if the key-share metadata is invalid, the commitments do not contain the
+    /// complete canonical committee, or the nonce session and key share belong to different parties.
     pub fn sign_round(
         self,
         session_id: Uuid,
@@ -45,7 +54,22 @@ impl EdDSASessionAdditive {
         message: BaseField,
         public_key: &EdDSAPublicKey,
         EdDSACommitmentsAdditive(challenge_input): EdDSACommitmentsAdditive,
-    ) -> EdDSASigShareAdditive {
+    ) -> eyre::Result<EdDSASigShareAdditive> {
+        let parties = &challenge_input.contributing_parties;
+        crate::commit::EdDSACommitments::validate_party_ids(parties)?;
+        if x_share.party_id == 0
+            || x_share.number_of_parties == 0
+            || x_share.party_id > x_share.number_of_parties
+        {
+            eyre::bail!("invalid additive key-share metadata");
+        }
+        let expected = (1..=x_share.number_of_parties).collect::<Vec<_>>();
+        if parties.as_slice() != expected {
+            eyre::bail!("additive signing requires the complete canonical party set");
+        }
+        if self.0.party_id != x_share.party_id {
+            eyre::bail!("nonce session and key share belong to different parties");
+        }
         // Recombine the two-nonce randomness shares into the full randomness used in the challenge.
         let (r, b) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
             session_id,
@@ -61,7 +85,10 @@ impl EdDSASessionAdditive {
 
         // The following modular reduction in convert_base_to_scalar is required in rust to perform the scalar multiplications. Using all 254 bits of the base field in a double/add ladder would apply this reduction implicitly. We show in the docs of convert_base_to_scalar why this does not introduce a bias when applied to a uniform element of the base field.
         let c_ = eddsa_babyjubjub::convert_base_to_scalar(c);
-        let share = EdDSASigShare(self.0.d + b * self.0.e + c_ * x_share.0);
-        EdDSASigShareAdditive(share)
+        let share = EdDSASigShare(
+            x_share.party_id,
+            self.0.d + b * self.0.e + c_ * x_share.value,
+        );
+        Ok(EdDSASigShareAdditive(share))
     }
 }

--- a/threshold-eddsa-babyjubjub/src/additive/session.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/session.rs
@@ -15,7 +15,6 @@ use crate::{
     session::EdDSASession,
     signature::EdDSASigShare,
 };
-use eddsa_babyjubjub::EdDSAPublicKey;
 use rand::{CryptoRng, Rng};
 use uuid::Uuid;
 use zeroize::ZeroizeOnDrop;
@@ -44,6 +43,9 @@ impl EdDSASessionAdditive {
     /// Finalizes a signature share for a given challenge hash and session.
     /// The session and information therein is consumed to prevent reuse of the randomness.
     ///
+    /// The public key is derived from the identity-bound key share rather than taken as an argument,
+    /// so the signer never signs against a key it cannot check.
+    ///
     /// # Errors
     /// Returns an error if the key-share metadata is invalid, the commitments do not contain the
     /// complete canonical committee, or the nonce session and key share belong to different parties.
@@ -52,9 +54,9 @@ impl EdDSASessionAdditive {
         session_id: Uuid,
         x_share: &DLogShareAdditive,
         message: BaseField,
-        public_key: &EdDSAPublicKey,
         EdDSACommitmentsAdditive(challenge_input): EdDSACommitmentsAdditive,
     ) -> eyre::Result<EdDSASigShareAdditive> {
+        let public_key = x_share.public_key();
         let parties = &challenge_input.contributing_parties;
         crate::commit::EdDSACommitments::validate_party_ids(parties)?;
         if x_share.party_id == 0

--- a/threshold-eddsa-babyjubjub/src/additive/signature.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/signature.rs
@@ -1,0 +1,14 @@
+//! Signature shares for the additive threshold `EdDSA` protocol.
+//!
+//! This module defines the `EdDSASigShareAdditive` struct, one party's share of the response `s`
+//! of the final `EdDSA` signature.
+
+use crate::signature::EdDSASigShare;
+use serde::{Deserialize, Serialize};
+
+/// Individual party's signature share for the additive `EdDSA` signature protocol.
+///
+/// Wraps the share of the challenge response for additive secret sharing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EdDSASigShareAdditive(pub(crate) EdDSASigShare);

--- a/threshold-eddsa-babyjubjub/src/additive/signature.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/signature.rs
@@ -12,3 +12,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct EdDSASigShareAdditive(pub(crate) EdDSASigShare);
+
+impl EdDSASigShareAdditive {
+    /// Return the party ID bound into this signature share.
+    #[must_use]
+    pub fn party_id(&self) -> u16 {
+        self.0.0
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/additive/test.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/test.rs
@@ -17,25 +17,28 @@ fn test_distributed_eddsa(num_parties: usize, cheating_parties: &[usize]) {
     let mut rng = rand::thread_rng();
 
     let message = BaseField::rand(&mut rng);
-    // Random x shares
-    let x_shares = (1..=num_parties)
-        .map(|party_id| {
+    // Random additive scalars, summing to the signing key
+    let scalars = (0..num_parties)
+        .map(|_| ScalarField::rand(&mut rng))
+        .collect::<Vec<_>>();
+    let x = scalars.iter().fold(ScalarField::zero(), |acc, s| acc + s);
+
+    // Create public keys, then bind each scalar to its identity and that key
+    let public_key = (Affine::generator() * x).into_affine();
+    let public_key_typed = EdDSAPublicKey { pk: public_key };
+    let x_shares = scalars
+        .iter()
+        .enumerate()
+        .map(|(position, &value)| {
             DLogShareAdditive::new(
-                ScalarField::rand(&mut rng),
-                u16::try_from(party_id).expect("party ID fits"),
+                value,
+                &public_key_typed,
+                u16::try_from(position + 1).expect("party ID fits"),
                 u16::try_from(num_parties).expect("party count fits"),
             )
             .expect("valid additive share metadata")
         })
         .collect::<Vec<_>>();
-
-    // Combine x shares
-    let x = x_shares
-        .iter()
-        .fold(ScalarField::zero(), |acc, x| acc + x.value);
-
-    // Create public keys
-    let public_key = (Affine::generator() * x).into_affine();
     let x_share_commitments = x_shares
         .iter()
         .map(|x| (x.party_id, (Affine::generator() * x.value).into_affine()))
@@ -69,7 +72,7 @@ fn test_distributed_eddsa(num_parties: usize, cheating_parties: &[usize]) {
     let mut signatures = Vec::with_capacity(num_parties);
     for (session, x_) in sessions.into_iter().zip(x_shares.iter()) {
         let signature = session
-            .sign_round(session_id, x_, message, &public_key, challenge.clone())
+            .sign_round(session_id, x_, message, challenge.clone())
             .expect("valid additive signing package");
         signatures.push(signature);
     }
@@ -105,9 +108,8 @@ fn test_distributed_eddsa(num_parties: usize, cheating_parties: &[usize]) {
         match result {
             Err(error) => assert_eq!(
                 error
-                    .downcast::<crate::MaliciousPartiesError>()
-                    .expect("malicious-party error")
-                    .into_inner(),
+                    .into_malicious_parties()
+                    .expect("the abort must attribute blame, not report bad input"),
                 cheating_parties,
             ),
             Ok(_) => panic!("cheating parties must be identified"),

--- a/threshold-eddsa-babyjubjub/src/additive/test.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/test.rs
@@ -10,6 +10,7 @@ use crate::{
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{UniformRand, Zero};
 use eddsa_babyjubjub::EdDSAPublicKey;
+use std::collections::BTreeMap;
 use uuid::Uuid;
 
 fn test_distributed_eddsa(num_parties: usize, cheating_parties: &[usize]) {
@@ -17,23 +18,30 @@ fn test_distributed_eddsa(num_parties: usize, cheating_parties: &[usize]) {
 
     let message = BaseField::rand(&mut rng);
     // Random x shares
-    let x_shares = (0..num_parties)
-        .map(|_| DLogShareAdditive(ScalarField::rand(&mut rng)))
+    let x_shares = (1..=num_parties)
+        .map(|party_id| {
+            DLogShareAdditive::new(
+                ScalarField::rand(&mut rng),
+                u16::try_from(party_id).expect("party ID fits"),
+                u16::try_from(num_parties).expect("party count fits"),
+            )
+            .expect("valid additive share metadata")
+        })
         .collect::<Vec<_>>();
 
     // Combine x shares
     let x = x_shares
         .iter()
-        .fold(ScalarField::zero(), |acc, x| acc + x.0);
+        .fold(ScalarField::zero(), |acc, x| acc + x.value);
 
     // Create public keys
     let public_key = (Affine::generator() * x).into_affine();
     let x_share_commitments = x_shares
         .iter()
-        .map(|x| (Affine::generator() * x.0).into_affine())
-        .collect::<Vec<_>>();
+        .map(|x| (x.party_id, (Affine::generator() * x.value).into_affine()))
+        .collect::<BTreeMap<_, _>>();
     let public_key_ = x_share_commitments
-        .iter()
+        .values()
         .fold(Projective::zero(), |acc, x| acc + x)
         .into_affine();
     assert_eq!(public_key, public_key_);
@@ -45,37 +53,39 @@ fn test_distributed_eddsa(num_parties: usize, cheating_parties: &[usize]) {
     // 1) Aggregator requests commitments from all servers
     let mut sessions = Vec::with_capacity(num_parties);
     let mut commitments = Vec::with_capacity(num_parties);
-    for id in 0..num_parties {
-        let (session, comm) = EdDSASessionAdditive::pre_round(&mut rng);
+    for id in 1..=num_parties {
+        let party_id = u16::try_from(id).expect("party ID fits");
+        let (session, comm) =
+            EdDSASessionAdditive::pre_round(party_id, &mut rng).expect("valid party ID");
         sessions.push(session);
-        commitments.push((u16::try_from(id + 1).expect("Can fit into u16"), comm));
+        commitments.push(comm);
     }
 
     // 2) Aggregator accumulates commitments and creates challenge
-    let challenge = EdDSACommitmentsAdditive::pre_agg(&commitments);
+    let challenge =
+        EdDSACommitmentsAdditive::pre_agg(&commitments).expect("valid identity-bound commitments");
 
     // 3) Aggregator challenges all servers
     let mut signatures = Vec::with_capacity(num_parties);
     for (session, x_) in sessions.into_iter().zip(x_shares.iter()) {
-        let signature = session.sign_round(session_id, x_, message, &public_key, challenge.clone());
+        let signature = session
+            .sign_round(session_id, x_, message, &public_key, challenge.clone())
+            .expect("valid additive signing package");
         signatures.push(signature);
     }
 
     for &party_id in cheating_parties {
-        signatures[party_id - 1].0.0 += ScalarField::from(1_u64);
+        signatures[party_id - 1].0.1 += ScalarField::from(1_u64);
     }
 
     // 4) Aggregator combines received signature shares
-    let partial_commitments = commitments
-        .iter()
-        .map(|(_, commitment)| commitment.clone())
-        .collect::<Vec<_>>();
+    let partial_commitments = commitments.clone();
 
     // Without identifiable abort
-    let signature_noabort =
-        challenge
-            .clone()
-            .sign_agg(session_id, &signatures, message, public_key.clone());
+    let signature_noabort = challenge
+        .clone()
+        .sign_agg(session_id, &signatures, message, public_key.clone())
+        .expect("signature shares match the party set");
 
     // With identifiable abort
     let result = challenge.sign_agg_with_identifiable_abort(
@@ -93,7 +103,13 @@ fn test_distributed_eddsa(num_parties: usize, cheating_parties: &[usize]) {
         assert!(public_key.verify(message, &signature_noabort));
     } else {
         match result {
-            Err(error) => assert_eq!(error.into_inner(), cheating_parties),
+            Err(error) => assert_eq!(
+                error
+                    .downcast::<crate::MaliciousPartiesError>()
+                    .expect("malicious-party error")
+                    .into_inner(),
+                cheating_parties,
+            ),
             Ok(_) => panic!("cheating parties must be identified"),
         }
         assert!(!public_key.verify(message, &signature_noabort));

--- a/threshold-eddsa-babyjubjub/src/additive/test.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/test.rs
@@ -1,0 +1,116 @@
+//! End-to-end tests for the additive threshold `EdDSA` protocol, covering both plain aggregation
+//! and aggregation with identifiable abort.
+
+use crate::{
+    Affine, BaseField, Projective, ScalarField,
+    additive::{
+        commit::EdDSACommitmentsAdditive, secret::DLogShareAdditive, session::EdDSASessionAdditive,
+    },
+};
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::{UniformRand, Zero};
+use eddsa_babyjubjub::EdDSAPublicKey;
+use uuid::Uuid;
+
+fn test_distributed_eddsa(num_parties: usize, cheating_parties: &[usize]) {
+    let mut rng = rand::thread_rng();
+
+    let message = BaseField::rand(&mut rng);
+    // Random x shares
+    let x_shares = (0..num_parties)
+        .map(|_| DLogShareAdditive(ScalarField::rand(&mut rng)))
+        .collect::<Vec<_>>();
+
+    // Combine x shares
+    let x = x_shares
+        .iter()
+        .fold(ScalarField::zero(), |acc, x| acc + x.0);
+
+    // Create public keys
+    let public_key = (Affine::generator() * x).into_affine();
+    let x_share_commitments = x_shares
+        .iter()
+        .map(|x| (Affine::generator() * x.0).into_affine())
+        .collect::<Vec<_>>();
+    let public_key_ = x_share_commitments
+        .iter()
+        .fold(Projective::zero(), |acc, x| acc + x)
+        .into_affine();
+    assert_eq!(public_key, public_key_);
+    let public_key = EdDSAPublicKey { pk: public_key };
+
+    // Crete session
+    let session_id = Uuid::new_v4();
+
+    // 1) Aggregator requests commitments from all servers
+    let mut sessions = Vec::with_capacity(num_parties);
+    let mut commitments = Vec::with_capacity(num_parties);
+    for id in 0..num_parties {
+        let (session, comm) = EdDSASessionAdditive::pre_round(&mut rng);
+        sessions.push(session);
+        commitments.push((u16::try_from(id + 1).expect("Can fit into u16"), comm));
+    }
+
+    // 2) Aggregator accumulates commitments and creates challenge
+    let challenge = EdDSACommitmentsAdditive::pre_agg(&commitments);
+
+    // 3) Aggregator challenges all servers
+    let mut signatures = Vec::with_capacity(num_parties);
+    for (session, x_) in sessions.into_iter().zip(x_shares.iter().cloned()) {
+        let signature = session.sign_round(session_id, x_, message, &public_key, challenge.clone());
+        signatures.push(signature);
+    }
+
+    for &party_id in cheating_parties {
+        signatures[party_id - 1].0.0 += ScalarField::from(1_u64);
+    }
+
+    // 4) Aggregator combines received signature shares
+    let partial_commitments = commitments
+        .iter()
+        .map(|(_, commitment)| commitment.clone())
+        .collect::<Vec<_>>();
+
+    // Without identifiable abort
+    let signature_noabort =
+        challenge
+            .clone()
+            .sign_agg(session_id, &signatures, message, public_key.clone());
+
+    // With identifiable abort
+    let result = challenge.sign_agg_with_identifiable_abort(
+        session_id,
+        &signatures,
+        message,
+        &public_key,
+        &x_share_commitments,
+        &partial_commitments,
+    );
+
+    if cheating_parties.is_empty() {
+        let signature = result.expect("honest parties produce a signature");
+        assert!(public_key.verify(message, &signature));
+        assert!(public_key.verify(message, &signature_noabort));
+    } else {
+        match result {
+            Err(error) => assert_eq!(error.into_inner(), cheating_parties),
+            Ok(_) => panic!("cheating parties must be identified"),
+        }
+        assert!(!public_key.verify(message, &signature_noabort));
+    }
+}
+
+#[test]
+fn test_distributed_eddsa_3_parties() {
+    test_distributed_eddsa(3, &[]);
+}
+
+#[test]
+fn test_distributed_eddsa_30_parties() {
+    test_distributed_eddsa(31, &[]);
+}
+
+#[test]
+fn test_distributed_eddsa_identifies_cheating_parties() {
+    test_distributed_eddsa(5, &[2, 4]);
+}

--- a/threshold-eddsa-babyjubjub/src/additive/test.rs
+++ b/threshold-eddsa-babyjubjub/src/additive/test.rs
@@ -56,7 +56,7 @@ fn test_distributed_eddsa(num_parties: usize, cheating_parties: &[usize]) {
 
     // 3) Aggregator challenges all servers
     let mut signatures = Vec::with_capacity(num_parties);
-    for (session, x_) in sessions.into_iter().zip(x_shares.iter().cloned()) {
+    for (session, x_) in sessions.into_iter().zip(x_shares.iter()) {
         let signature = session.sign_round(session_id, x_, message, &public_key, challenge.clone());
         signatures.push(signature);
     }

--- a/threshold-eddsa-babyjubjub/src/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/commit.rs
@@ -89,6 +89,7 @@ impl<'de> Deserialize<'de> for EdDSACommitments {
             d: Affine,
             #[serde(with = "babyjubjub::affine")]
             e: Affine,
+            #[serde(deserialize_with = "crate::serde_utils::deserialize_protocol_vec")]
             contributing_parties: Vec<u16>,
         }
 

--- a/threshold-eddsa-babyjubjub/src/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/commit.rs
@@ -63,6 +63,21 @@ impl EdDSACommitments {
 
         EdDSASignature { r, s }
     }
+
+    pub(crate) fn validate_party_ids(parties: &[u16]) {
+        assert!(
+            !parties.is_empty(),
+            "at least one contributing party is required"
+        );
+        assert!(
+            parties.iter().all(|id| *id != 0),
+            "party IDs must be non-zero"
+        );
+        let mut unique = parties.to_vec();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), parties.len(), "party IDs must be unique");
+    }
 }
 
 // This is modelled after the `verify` function in `eddsa-babyjubjub/src/lib.rs`, but it takes the challenge as input

--- a/threshold-eddsa-babyjubjub/src/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/commit.rs
@@ -1,0 +1,93 @@
+//! Aggregated Commitments for Threshold `EdDSA`
+//!
+//! This module defines the `EdDSACommitments` struct, which holds the sum of the per-party
+//! commitment shares and is used both as the challenge hash input and to combine the received
+//! signature shares into the final `EdDSA` signature.
+//!
+//! The primitives defined here are agnostic to the underlying threshold sharing scheme and are used by both
+//! additive and Shamir variants, which are implemented in their respective submodules `additive` and `shamir`.
+//!
+//! This module provides:
+//! - The aggregated two-nonce commitment (`d`, `e`) together with the set of contributing parties.
+//! - Combination of the signature shares, and the challenge-based verification used for identifiable abort.
+
+use crate::{
+    Affine, BaseField, ScalarField, nonce::CombineTwoNonceRandomnessArgs, signature::EdDSASigShare,
+};
+use ark_ec::AffineRepr;
+use ark_ff::{AdditiveGroup, PrimeField, Zero};
+use ark_serde_compat::babyjubjub;
+use eddsa_babyjubjub::{EdDSAPublicKey, EdDSASignature};
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Aggregated commitments for the distributed `EdDSA` protocol.
+///
+/// This struct aggregates the per-party commitment shares, to be used as the challenge hash input, and to verify against the full proof after all shares are combined.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EdDSACommitments {
+    #[serde(with = "babyjubjub::affine")]
+    /// The aggregated G*d.
+    pub(crate) d: Affine,
+    #[serde(with = "babyjubjub::affine")]
+    /// The aggregated G*e.
+    pub(crate) e: Affine,
+    /// The parties that contributed to this commitment.
+    pub(crate) contributing_parties: Vec<u16>,
+}
+
+impl EdDSACommitments {
+    /// Combine all parties' signature shares into a single `EdDSA` signature object.
+    ///
+    /// Must use the same order of contributing parties as in aggregation
+    pub(crate) fn sign_agg<'a>(
+        self,
+        session_id: Uuid,
+        shares: impl Iterator<Item = &'a EdDSASigShare>,
+        message: BaseField,
+        public_key: EdDSAPublicKey,
+    ) -> EdDSASignature {
+        let mut s = ScalarField::zero();
+        for share in shares {
+            s += share.0;
+        }
+        let (r, _) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
+            session_id,
+            message,
+            public_key,
+            d: self.d,
+            e: self.e,
+            parties: &self.contributing_parties,
+        });
+
+        EdDSASignature { r, s }
+    }
+}
+
+// This is modelled after the `verify` function in `eddsa-babyjubjub/src/lib.rs`, but it takes the challenge as input
+pub(crate) fn verify_for_identifiable_abort(
+    pk: &Affine,
+    r: Affine,
+    s: ScalarField,
+    c: ScalarField,
+) -> bool {
+    let s_biguint: BigUint = s.into();
+    if s_biguint >= ScalarField::MODULUS.into() {
+        return false;
+    }
+
+    if pk.is_zero()
+        || !pk.is_on_curve()
+        || !pk.is_in_correct_subgroup_assuming_on_curve()
+        || !r.is_on_curve()
+    {
+        return false;
+    }
+
+    let mut v = (Affine::generator() * s) - r - (*pk * c); // multiply by the cofactor 8
+    v.double_in_place();
+    v.double_in_place();
+    v.double_in_place();
+    v.is_zero()
+}

--- a/threshold-eddsa-babyjubjub/src/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/commit.rs
@@ -19,13 +19,13 @@ use ark_ff::{AdditiveGroup, PrimeField, Zero};
 use ark_serde_compat::babyjubjub;
 use eddsa_babyjubjub::{EdDSAPublicKey, EdDSASignature};
 use num_bigint::BigUint;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
 use uuid::Uuid;
 
 /// Aggregated commitments for the distributed `EdDSA` protocol.
 ///
 /// This struct aggregates the per-party commitment shares, to be used as the challenge hash input, and to verify against the full proof after all shares are combined.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct EdDSACommitments {
     #[serde(with = "babyjubjub::affine")]
     /// The aggregated G*d.
@@ -50,7 +50,7 @@ impl EdDSACommitments {
     ) -> EdDSASignature {
         let mut s = ScalarField::zero();
         for share in shares {
-            s += share.0;
+            s += share.1;
         }
         let (r, _) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
             session_id,
@@ -64,19 +64,41 @@ impl EdDSACommitments {
         EdDSASignature { r, s }
     }
 
-    pub(crate) fn validate_party_ids(parties: &[u16]) {
-        assert!(
-            !parties.is_empty(),
-            "at least one contributing party is required"
-        );
-        assert!(
-            parties.iter().all(|id| *id != 0),
-            "party IDs must be non-zero"
-        );
-        let mut unique = parties.to_vec();
-        unique.sort_unstable();
-        unique.dedup();
-        assert_eq!(unique.len(), parties.len(), "party IDs must be unique");
+    pub(crate) fn validate_party_ids(parties: &[u16]) -> eyre::Result<()> {
+        if parties.is_empty() {
+            eyre::bail!("at least one contributing party is required");
+        }
+        if parties[0] == 0 {
+            eyre::bail!("party IDs must be non-zero");
+        }
+        if parties.windows(2).any(|ids| ids[0] >= ids[1]) {
+            eyre::bail!("party IDs must be unique and canonically ordered");
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for EdDSACommitments {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Repr {
+            #[serde(with = "babyjubjub::affine")]
+            d: Affine,
+            #[serde(with = "babyjubjub::affine")]
+            e: Affine,
+            contributing_parties: Vec<u16>,
+        }
+
+        let repr = Repr::deserialize(deserializer)?;
+        Self::validate_party_ids(&repr.contributing_parties).map_err(D::Error::custom)?;
+        Ok(Self {
+            d: repr.d,
+            e: repr.e,
+            contributing_parties: repr.contributing_parties,
+        })
     }
 }
 

--- a/threshold-eddsa-babyjubjub/src/keygen/blame.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/blame.rs
@@ -57,6 +57,11 @@ pub struct BlameResult<C: CurveGroup> {
     /// The ordinary finalized DKG output, computed without disqualified dealer contributions.
     pub finished: Finished<C>,
     /// DKG dealers or old reshare senders excluded for invalid or missing protocol messages.
+    ///
+    /// Their polynomial contribution is dropped from the output. A DKG dealer disqualified in the
+    /// blame round nonetheless remains a shareholder and keeps a `pk_shares` entry, because it can
+    /// compute its share of the surviving aggregate polynomial regardless; exclude it from future
+    /// signing committees at the application layer if that is the intent.
     pub disqualified_parties: Vec<u16>,
     /// Verdict participants omitted after an externally agreed timeout.
     ///
@@ -211,15 +216,36 @@ impl<C: CurveGroup> BlameRound<C> {
 
     /// Create this dealer's revelation broadcast if another party accused it.
     ///
-    /// Calling this also marks the local dealer's valid revelation as resolved.
+    /// The accuser set is derived from the verdicts collected with
+    /// [`BlameRound::add_verdict`] and is never supplied by the caller, so a party that did not
+    /// broadcast a blaming verdict is never answered.
+    ///
+    /// This does *not* mark the local dealer as resolved. Feed the revelation back through
+    /// [`BlameRound::add_revelation`] as the broadcast channel actually delivered it, exactly as
+    /// every other party does. Otherwise a dealer whose broadcast was corrupted or truncated in
+    /// transit would judge itself qualified while everyone else disqualified it, and would silently
+    /// end up holding a share of a different key.
     ///
     /// # Errors
-    /// Returns an error until all verdict broadcasts have been collected.
+    /// Returns an error until all verdict broadcasts have been collected, or if answering the
+    /// accusers would reveal enough evaluations to interpolate this dealer's polynomial. The latter
+    /// cannot happen while at most `threshold - 1` parties are corrupted, because an honest dealer
+    /// is never accused by an honest party.
     pub fn revelation(&mut self) -> Result<Option<BlameRevelation<C>>> {
         let accusations = self.accusations()?;
         let Some(accusers) = accusations.get(&self.my_idx) else {
             return Ok(None);
         };
+        let threshold = usize::from(self.params.threshold);
+        if accusers.len() >= threshold {
+            eyre::bail!(
+                "refusing to reveal {} evaluations of a degree-{} polynomial: at a threshold of \
+                 {threshold} this would disclose party {}'s polynomial",
+                accusers.len(),
+                self.params.degree(),
+                self.my_idx,
+            );
+        }
         let shares = accusers
             .iter()
             .map(|receiver| RevealedShare {
@@ -227,7 +253,6 @@ impl<C: CurveGroup> BlameRound<C> {
                 share: self.secret_shares[usize::from(*receiver) - 1],
             })
             .collect();
-        self.resolved_dealers.insert(self.my_idx);
         Ok(Some(BlameRevelation {
             session_id: self.session_id,
             shares,
@@ -239,11 +264,23 @@ impl<C: CurveGroup> BlameRound<C> {
     /// A dealer is disqualified if the broadcast is malformed or any revealed share fails its
     /// polynomial equation. A valid revelation replaces the private value held by its receiver.
     ///
+    /// `from` may be the local party: an accused dealer must judge its own broadcast as the channel
+    /// delivered it, so that it reaches the same verdict about itself as everyone else and cannot
+    /// finalize onto a key the other parties are not using.
+    ///
     /// # Errors
     /// Returns an error for an invalid sender, duplicate resolution, or an unaccused sender.
     /// Invalid revelations are recorded as dealer disqualifications.
     pub fn add_revelation(&mut self, from: u16, revelation: &BlameRevelation<C>) -> Result<()> {
-        self.validate_other_party(from)?;
+        if from == 0 {
+            eyre::bail!("party index must be non-zero");
+        }
+        if from > self.params.number_of_parties {
+            eyre::bail!("party index {from} invalid for parameters");
+        }
+        if !self.commitments.contains_key(&from) {
+            eyre::bail!("party {from} was disqualified before the blame round");
+        }
         let accusations = self.accusations()?;
         let Some(expected_receivers) = accusations.get(&from) else {
             eyre::bail!("party {from} was not accused");
@@ -322,9 +359,20 @@ impl<C: CurveGroup> BlameRound<C> {
 
     /// Finalize the DKG from all non-disqualified dealer contributions.
     ///
+    /// A dealer disqualified during this blame round has its *polynomial* dropped from the aggregate,
+    /// as `PedPoP` prescribes, but remains a *shareholder*: it completed round two, so it received
+    /// every qualified dealer's evaluation and can compute its own share of the aggregate polynomial
+    /// whether or not the honest parties record one for it. Withholding its public-key share would
+    /// therefore buy no security while desynchronizing the views and shrinking the shareholder set.
+    /// Its ID is still reported in [`BlameResult::disqualified_parties`], so an integrator that does
+    /// not want a proven cheater in future signing committees can exclude it at that layer.
+    ///
+    /// Parties disqualified back in round one are a different case and are *not* shareholders: they
+    /// never reached round two, so they hold nothing to build a share from.
+    ///
     /// # Errors
-    /// Returns an error until every verdict and required revelation has been processed, or if all
-    /// dealers were disqualified.
+    /// Returns an error until every verdict and required revelation has been processed, or if fewer
+    /// than the threshold number of dealer contributions survive.
     pub fn finalize(self) -> Result<BlameResult<C>> {
         if !self.verdicts_complete() {
             eyre::bail!("cannot finalize before all verdicts are received");
@@ -332,10 +380,9 @@ impl<C: CurveGroup> BlameRound<C> {
         if !self.missing_revelations()?.is_empty() {
             eyre::bail!("cannot finalize before all accusations are resolved");
         }
-        if self.disqualified_dealers.contains(&self.my_idx) {
-            eyre::bail!("local party was disqualified and cannot obtain a secret-key share");
-        }
 
+        // Everyone that completed round two, blame-disqualified dealers included.
+        let shareholders = self.commitments.keys().copied().collect::<Vec<_>>();
         let qualified_dealers = self
             .commitments
             .keys()
@@ -357,12 +404,7 @@ impl<C: CurveGroup> BlameRound<C> {
                     }
                 });
         let mut public_key_shares = HashMap::new();
-        for party in self
-            .commitments
-            .keys()
-            .filter(|party| !self.disqualified_dealers.contains(party))
-            .copied()
-        {
+        for party in shareholders {
             let share = qualified_dealers
                 .iter()
                 .fold(C::zero(), |acc, dealer| {

--- a/threshold-eddsa-babyjubjub/src/keygen/blame.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/blame.rs
@@ -5,7 +5,7 @@
 //! parties verify those revelations against the dealer's polynomial commitments.
 
 use crate::{
-    keygen::{Parameters, SecretScalars, finished::Finished, round2::RoundTwo},
+    keygen::{Parameters, SecretScalarMap, SecretScalars, finished::Finished, round2::RoundTwo},
     shamir::utils,
 };
 use ark_ec::CurveGroup;
@@ -51,13 +51,18 @@ pub struct BlameRevelation<C: CurveGroup> {
     pub(crate) shares: Vec<RevealedShare<C>>,
 }
 
-/// Successful output of a DKG that used the optional blame round.
+/// Successful output of DKG or resharing that used the optional blame round.
 #[non_exhaustive]
 pub struct BlameResult<C: CurveGroup> {
     /// The ordinary finalized DKG output, computed without disqualified dealer contributions.
     pub finished: Finished<C>,
-    /// Dealers identified by invalid, malformed, or missing revelations.
+    /// DKG dealers or old reshare senders excluded for invalid or missing protocol messages.
     pub disqualified_parties: Vec<u16>,
+    /// Verdict participants omitted after an externally agreed timeout.
+    ///
+    /// This is empty for DKG. During resharing these are new receivers whose missing verdict was
+    /// ignored for liveness; it does not revoke any key share they may already hold.
+    pub excluded_verdict_parties: Vec<u16>,
 }
 
 /// State for the optional public DKG complaint and blame workflow.
@@ -67,7 +72,7 @@ pub struct BlameRound<C: CurveGroup> {
     secret_shares: SecretScalars<C::ScalarField>,
     my_idx: u16,
     params: Parameters,
-    received_party_messages: HashMap<u16, C::ScalarField>,
+    received_party_messages: SecretScalarMap<C::ScalarField>,
     verdicts: BTreeMap<u16, BlameVerdict>,
     resolved_dealers: BTreeSet<u16>,
     disqualified_dealers: BTreeSet<u16>,
@@ -95,7 +100,7 @@ impl<C: CurveGroup> BlameRound<C> {
             received_party_messages: round_two.received_party_messages,
             verdicts,
             resolved_dealers: BTreeSet::new(),
-            disqualified_dealers: BTreeSet::new(),
+            disqualified_dealers: round_two.disqualified_parties,
         })
     }
 
@@ -112,17 +117,24 @@ impl<C: CurveGroup> BlameRound<C> {
     /// party identifier.
     pub fn add_verdict(&mut self, from: u16, verdict: BlameVerdict) -> Result<()> {
         self.validate_other_party(from)?;
+        if !self.commitments.contains_key(&from) {
+            eyre::bail!("party {from} was disqualified before the blame round");
+        }
+        if self.disqualified_dealers.contains(&from) {
+            eyre::bail!("party {from} was disqualified after missing its blame verdict");
+        }
         if self.verdicts.contains_key(&from) {
             eyre::bail!("already added blame verdict for party {from}");
         }
         if verdict.session_id != self.session_id {
             eyre::bail!("session id mismatch in blame verdict from party {from}");
         }
-        if verdict
-            .blamed_parties
-            .iter()
-            .any(|party| *party == 0 || *party > self.params.number_of_parties || *party == from)
-        {
+        if verdict.blamed_parties.iter().any(|party| {
+            *party == 0
+                || *party > self.params.number_of_parties
+                || *party == from
+                || !self.commitments.contains_key(party)
+        }) {
             eyre::bail!("invalid blamed party in verdict from party {from}");
         }
         self.verdicts.insert(from, verdict);
@@ -132,15 +144,52 @@ impl<C: CurveGroup> BlameRound<C> {
     /// Parties whose first blame-round broadcasts are still missing.
     #[must_use]
     pub fn missing_verdicts(&self) -> Vec<u16> {
-        (1..=self.params.number_of_parties)
+        self.commitments
+            .keys()
             .filter(|party| !self.verdicts.contains_key(party))
+            .filter(|party| !self.disqualified_dealers.contains(party))
+            .copied()
             .collect()
     }
 
     /// Whether every party's `Ok` or blame-set broadcast has been received.
     #[must_use]
     pub fn verdicts_complete(&self) -> bool {
-        self.verdicts.len() == usize::from(self.params.number_of_parties)
+        self.missing_verdicts().is_empty()
+    }
+
+    /// Disqualify a dealer whose blame verdict was missing or rejected.
+    ///
+    /// All honest parties must apply the same decision after an externally agreed deadline. The
+    /// dealer's polynomial contribution is excluded from the final DKG output.
+    ///
+    /// # Errors
+    /// Returns an error for an invalid, pre-disqualified, local, already-resolved party, or a party
+    /// whose verdict was already accepted. It also returns an error if disqualification would leave
+    /// fewer than the configured threshold parties.
+    pub fn disqualify_missing_verdict(&mut self, party: u16) -> Result<()> {
+        self.validate_other_party(party)?;
+        if !self.commitments.contains_key(&party) {
+            eyre::bail!("party {party} was disqualified before the blame round");
+        }
+        if self.verdicts.contains_key(&party) {
+            eyre::bail!("party {party}'s blame verdict was already accepted");
+        }
+        if self.disqualified_dealers.contains(&party) {
+            eyre::bail!("party {party} was already disqualified");
+        }
+        let remaining = self
+            .commitments
+            .keys()
+            .filter(|dealer| !self.disqualified_dealers.contains(dealer))
+            .filter(|dealer| **dealer != party)
+            .count();
+        if remaining < usize::from(self.params.threshold) {
+            eyre::bail!("verdict disqualification would leave fewer than the threshold parties");
+        }
+        self.disqualified_dealers.insert(party);
+        self.resolved_dealers.insert(party);
+        Ok(())
     }
 
     /// Return the map from every accused dealer to its accusers.
@@ -227,7 +276,12 @@ impl<C: CurveGroup> BlameRound<C> {
                 .iter()
                 .find(|revealed| revealed.receiver == self.my_idx)
             {
-                self.received_party_messages.insert(from, revealed.share);
+                use zeroize::Zeroize as _;
+                if let Some(mut previous) =
+                    self.received_party_messages.insert(from, revealed.share)
+                {
+                    previous.zeroize();
+                }
             }
         } else {
             self.disqualified_dealers.insert(from);
@@ -282,11 +336,14 @@ impl<C: CurveGroup> BlameRound<C> {
             eyre::bail!("local party was disqualified and cannot obtain a secret-key share");
         }
 
-        let qualified_dealers = (1..=self.params.number_of_parties)
+        let qualified_dealers = self
+            .commitments
+            .keys()
             .filter(|dealer| !self.disqualified_dealers.contains(dealer))
+            .copied()
             .collect::<Vec<_>>();
-        if qualified_dealers.is_empty() {
-            eyre::bail!("cannot finalize after all dealers were disqualified");
+        if qualified_dealers.len() < usize::from(self.params.threshold) {
+            eyre::bail!("cannot finalize with fewer than the threshold qualified parties");
         }
 
         let my_secret_key_share =
@@ -300,8 +357,11 @@ impl<C: CurveGroup> BlameRound<C> {
                     }
                 });
         let mut public_key_shares = HashMap::new();
-        for party in (1..=self.params.number_of_parties)
+        for party in self
+            .commitments
+            .keys()
             .filter(|party| !self.disqualified_dealers.contains(party))
+            .copied()
         {
             let share = qualified_dealers
                 .iter()
@@ -327,6 +387,7 @@ impl<C: CurveGroup> BlameRound<C> {
                 pk: public_key.into_affine(),
             },
             disqualified_parties: self.disqualified_dealers.into_iter().collect(),
+            excluded_verdict_parties: Vec::new(),
         })
     }
 

--- a/threshold-eddsa-babyjubjub/src/keygen/blame.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/blame.rs
@@ -1,0 +1,363 @@
+//! Optional public complaint and blame round for distributed key generation.
+//!
+//! Parties first broadcast either `Ok` or the set of dealers whose private shares failed
+//! verification. Every accused dealer then broadcasts the committed share for each accuser. All
+//! parties verify those revelations against the dealer's polynomial commitments.
+
+use crate::{
+    keygen::{Parameters, SecretScalars, finished::Finished, round2::RoundTwo},
+    shamir::utils,
+};
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::Zero;
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use uuid::Uuid;
+
+/// A party's first broadcast in the blame round.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlameVerdict {
+    pub(crate) session_id: Uuid,
+    pub(crate) blamed_parties: BTreeSet<u16>,
+}
+
+impl BlameVerdict {
+    /// Returns the parties accused by this verdict. An empty set represents `Ok`.
+    #[must_use]
+    pub fn blamed_parties(&self) -> &BTreeSet<u16> {
+        &self.blamed_parties
+    }
+
+    /// Returns whether the sender reported that every private share was valid.
+    #[must_use]
+    pub fn is_ok(&self) -> bool {
+        self.blamed_parties.is_empty()
+    }
+}
+
+/// One private polynomial evaluation made public in response to a complaint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevealedShare<C: CurveGroup> {
+    pub(crate) receiver: u16,
+    #[serde(with = "ark_serde_compat::field")]
+    pub(crate) share: C::ScalarField,
+}
+
+/// An accused dealer's share-revelation broadcast in the blame round.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlameRevelation<C: CurveGroup> {
+    pub(crate) session_id: Uuid,
+    pub(crate) shares: Vec<RevealedShare<C>>,
+}
+
+/// Successful output of a DKG that used the optional blame round.
+#[non_exhaustive]
+pub struct BlameResult<C: CurveGroup> {
+    /// The ordinary finalized DKG output, computed without disqualified dealer contributions.
+    pub finished: Finished<C>,
+    /// Dealers identified by invalid, malformed, or missing revelations.
+    pub disqualified_parties: Vec<u16>,
+}
+
+impl<C: CurveGroup> BlameResult<C> {
+    /// Return every disqualified party together with its default public-key share.
+    ///
+    /// Disqualified parties are inactive in the finalized sharing and therefore have the identity
+    /// point as their entry in [`Finished::pk_shares`].
+    #[must_use]
+    pub fn disqualified_public_key_shares(&self) -> BTreeMap<u16, C::Affine> {
+        self.disqualified_parties
+            .iter()
+            .map(|party| (*party, self.finished.pk_shares[party]))
+            .collect()
+    }
+}
+
+/// State for the optional public DKG complaint and blame workflow.
+pub struct BlameRound<C: CurveGroup> {
+    session_id: Uuid,
+    commitments: HashMap<u16, Vec<C::Affine>>,
+    secret_shares: SecretScalars<C::ScalarField>,
+    my_idx: u16,
+    params: Parameters,
+    received_party_messages: HashMap<u16, C::ScalarField>,
+    verdicts: BTreeMap<u16, BlameVerdict>,
+    resolved_dealers: BTreeSet<u16>,
+    disqualified_dealers: BTreeSet<u16>,
+}
+
+impl<C: CurveGroup> BlameRound<C> {
+    pub(crate) fn new(round_two: RoundTwo<C>) -> Result<Self> {
+        if !round_two.can_advance() {
+            eyre::bail!("cannot enter blame round, not all private shares were received");
+        }
+
+        let own_verdict = BlameVerdict {
+            session_id: round_two.session_id,
+            blamed_parties: round_two.failed_parties,
+        };
+        let mut verdicts = BTreeMap::new();
+        verdicts.insert(round_two.my_idx, own_verdict);
+
+        Ok(Self {
+            session_id: round_two.session_id,
+            commitments: round_two.commitments,
+            secret_shares: round_two.secret_shares,
+            my_idx: round_two.my_idx,
+            params: round_two.params,
+            received_party_messages: round_two.received_party_messages,
+            verdicts,
+            resolved_dealers: BTreeSet::new(),
+            disqualified_dealers: BTreeSet::new(),
+        })
+    }
+
+    /// Return this party's `Ok` or blame-set broadcast.
+    #[must_use]
+    pub fn verdict(&self) -> BlameVerdict {
+        self.verdicts[&self.my_idx].clone()
+    }
+
+    /// Add another party's verdict broadcast.
+    ///
+    /// # Errors
+    /// Returns an error for an invalid sender, duplicate verdict, wrong session, or invalid blamed
+    /// party identifier.
+    pub fn add_verdict(&mut self, from: u16, verdict: BlameVerdict) -> Result<()> {
+        self.validate_other_party(from)?;
+        if self.verdicts.contains_key(&from) {
+            eyre::bail!("already added blame verdict for party {from}");
+        }
+        if verdict.session_id != self.session_id {
+            eyre::bail!("session id mismatch in blame verdict from party {from}");
+        }
+        if verdict
+            .blamed_parties
+            .iter()
+            .any(|party| *party == 0 || *party > self.params.number_of_parties || *party == from)
+        {
+            eyre::bail!("invalid blamed party in verdict from party {from}");
+        }
+        self.verdicts.insert(from, verdict);
+        Ok(())
+    }
+
+    /// Parties whose first blame-round broadcasts are still missing.
+    #[must_use]
+    pub fn missing_verdicts(&self) -> Vec<u16> {
+        (1..=self.params.number_of_parties)
+            .filter(|party| !self.verdicts.contains_key(party))
+            .collect()
+    }
+
+    /// Whether every party's `Ok` or blame-set broadcast has been received.
+    #[must_use]
+    pub fn verdicts_complete(&self) -> bool {
+        self.verdicts.len() == usize::from(self.params.number_of_parties)
+    }
+
+    /// Return the map from every accused dealer to its accusers.
+    ///
+    /// # Errors
+    /// Returns an error until all verdict broadcasts have been collected.
+    pub fn accusations(&self) -> Result<BTreeMap<u16, BTreeSet<u16>>> {
+        if !self.verdicts_complete() {
+            eyre::bail!("cannot determine accusations before all verdicts are received");
+        }
+        let mut accusations = BTreeMap::<u16, BTreeSet<u16>>::new();
+        for (&accuser, verdict) in &self.verdicts {
+            for &dealer in &verdict.blamed_parties {
+                accusations.entry(dealer).or_default().insert(accuser);
+            }
+        }
+        Ok(accusations)
+    }
+
+    /// Create this dealer's revelation broadcast if another party accused it.
+    ///
+    /// Calling this also marks the local dealer's valid revelation as resolved.
+    ///
+    /// # Errors
+    /// Returns an error until all verdict broadcasts have been collected.
+    pub fn revelation(&mut self) -> Result<Option<BlameRevelation<C>>> {
+        let accusations = self.accusations()?;
+        let Some(accusers) = accusations.get(&self.my_idx) else {
+            return Ok(None);
+        };
+        let shares = accusers
+            .iter()
+            .map(|receiver| RevealedShare {
+                receiver: *receiver,
+                share: self.secret_shares[usize::from(*receiver) - 1],
+            })
+            .collect();
+        self.resolved_dealers.insert(self.my_idx);
+        Ok(Some(BlameRevelation {
+            session_id: self.session_id,
+            shares,
+        }))
+    }
+
+    /// Add and publicly verify an accused dealer's revelation broadcast.
+    ///
+    /// A dealer is disqualified if the broadcast is malformed or any revealed share fails its
+    /// polynomial equation. A valid revelation replaces the private value held by its receiver.
+    ///
+    /// # Errors
+    /// Returns an error for an invalid sender, duplicate resolution, or an unaccused sender.
+    /// Invalid revelations are recorded as dealer disqualifications.
+    pub fn add_revelation(&mut self, from: u16, revelation: &BlameRevelation<C>) -> Result<()> {
+        self.validate_other_party(from)?;
+        let accusations = self.accusations()?;
+        let Some(expected_receivers) = accusations.get(&from) else {
+            eyre::bail!("party {from} was not accused");
+        };
+        if self.resolved_dealers.contains(&from) {
+            eyre::bail!("party {from}'s accusation was already resolved");
+        }
+
+        let revealed_receivers = revelation
+            .shares
+            .iter()
+            .map(|revealed| revealed.receiver)
+            .collect::<BTreeSet<_>>();
+        let duplicate_receiver = revealed_receivers.len() != revelation.shares.len();
+        let structurally_valid = revelation.session_id == self.session_id
+            && !duplicate_receiver
+            && &revealed_receivers == expected_receivers;
+        let equations_valid = structurally_valid
+            && revelation.shares.iter().all(|revealed| {
+                utils::verify_polynomial_evaluation::<C>(
+                    &self.commitments[&from],
+                    revealed.receiver,
+                    &revealed.share,
+                )
+            });
+
+        if equations_valid {
+            if let Some(revealed) = revelation
+                .shares
+                .iter()
+                .find(|revealed| revealed.receiver == self.my_idx)
+            {
+                self.received_party_messages.insert(from, revealed.share);
+            }
+        } else {
+            self.disqualified_dealers.insert(from);
+        }
+        self.resolved_dealers.insert(from);
+        Ok(())
+    }
+
+    /// Disqualify an accused dealer that failed to broadcast its shares before an externally
+    /// enforced timeout. All parties must apply the same timeout decision to retain agreement.
+    ///
+    /// # Errors
+    /// Returns an error if verdict collection is incomplete, the dealer was not accused, or its
+    /// accusation was already resolved.
+    pub fn disqualify_missing_dealer(&mut self, dealer: u16) -> Result<()> {
+        let accusations = self.accusations()?;
+        if !accusations.contains_key(&dealer) {
+            eyre::bail!("party {dealer} was not accused");
+        }
+        if !self.resolved_dealers.insert(dealer) {
+            eyre::bail!("party {dealer}'s accusation was already resolved");
+        }
+        self.disqualified_dealers.insert(dealer);
+        Ok(())
+    }
+
+    /// Accused dealers whose revelation or timeout resolution is still missing.
+    ///
+    /// # Errors
+    /// Returns an error until all verdict broadcasts have been collected.
+    pub fn missing_revelations(&self) -> Result<Vec<u16>> {
+        Ok(self
+            .accusations()?
+            .keys()
+            .filter(|dealer| !self.resolved_dealers.contains(dealer))
+            .copied()
+            .collect())
+    }
+
+    /// Finalize the DKG from all non-disqualified dealer contributions.
+    ///
+    /// # Errors
+    /// Returns an error until every verdict and required revelation has been processed, or if all
+    /// dealers were disqualified.
+    pub fn finalize(self) -> Result<BlameResult<C>> {
+        // The following is performed in accusations, which is called in missing_revelations
+        // if !self.verdicts_complete() {
+        //     eyre::bail!("cannot finalize before all verdicts are received");
+        // }
+        if !self.missing_revelations()?.is_empty() {
+            eyre::bail!("cannot finalize before all accusations are resolved");
+        }
+        if self.disqualified_dealers.contains(&self.my_idx) {
+            eyre::bail!("local party was disqualified and cannot obtain a secret-key share");
+        }
+
+        let qualified_dealers = (1..=self.params.number_of_parties)
+            .filter(|dealer| !self.disqualified_dealers.contains(dealer))
+            .collect::<Vec<_>>();
+        if qualified_dealers.is_empty() {
+            eyre::bail!("cannot finalize after all dealers were disqualified");
+        }
+
+        let my_secret_key_share =
+            qualified_dealers
+                .iter()
+                .fold(C::ScalarField::zero(), |acc, dealer| {
+                    if *dealer == self.my_idx {
+                        acc + self.secret_shares[usize::from(self.my_idx) - 1]
+                    } else {
+                        acc + self.received_party_messages[dealer]
+                    }
+                });
+        let mut public_key_shares = HashMap::new();
+        for party in 1..=self.params.number_of_parties {
+            let share = if self.disqualified_dealers.contains(&party) {
+                C::Affine::zero()
+            } else {
+                qualified_dealers
+                    .iter()
+                    .fold(C::zero(), |acc, dealer| {
+                        acc + utils::evaluate_polynomial_in_exponent::<C>(
+                            &self.commitments[dealer],
+                            party,
+                        )
+                    })
+                    .into_affine()
+            };
+            public_key_shares.insert(party, share);
+        }
+        let public_key = qualified_dealers
+            .iter()
+            .fold(C::zero(), |acc, dealer| acc + self.commitments[dealer][0]);
+
+        Ok(BlameResult {
+            finished: Finished {
+                my_idx: self.my_idx,
+                session_id: self.session_id,
+                sk_share: my_secret_key_share,
+                pk_shares: public_key_shares,
+                pk: public_key.into_affine(),
+            },
+            disqualified_parties: self.disqualified_dealers.into_iter().collect(),
+        })
+    }
+
+    fn validate_other_party(&self, from: u16) -> Result<()> {
+        if from == 0 {
+            eyre::bail!("party index must be non-zero",);
+        }
+        if from > self.params.number_of_parties {
+            eyre::bail!("party index {from} invalid for parameters",);
+        }
+        if from == self.my_idx {
+            eyre::bail!("do not add own party {from}'s broadcast");
+        }
+        Ok(())
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/keygen/blame.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/blame.rs
@@ -19,6 +19,7 @@ use uuid::Uuid;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlameVerdict {
     pub(crate) session_id: Uuid,
+    #[serde(deserialize_with = "crate::serde_utils::deserialize_protocol_btree_set")]
     pub(crate) blamed_parties: BTreeSet<u16>,
 }
 
@@ -48,6 +49,10 @@ pub struct RevealedShare<C: CurveGroup> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlameRevelation<C: CurveGroup> {
     pub(crate) session_id: Uuid,
+    #[serde(
+        serialize_with = "crate::serde_utils::serialize_protocol_vec",
+        deserialize_with = "crate::serde_utils::deserialize_protocol_vec"
+    )]
     pub(crate) shares: Vec<RevealedShare<C>>,
 }
 
@@ -383,12 +388,14 @@ impl<C: CurveGroup> BlameRound<C> {
 
         // Everyone that completed round two, blame-disqualified dealers included.
         let shareholders = self.commitments.keys().copied().collect::<Vec<_>>();
-        let qualified_dealers = self
+        // `commitments` is a `HashMap`; sort so the reported set is comparable across parties.
+        let mut qualified_dealers = self
             .commitments
             .keys()
             .filter(|dealer| !self.disqualified_dealers.contains(dealer))
             .copied()
             .collect::<Vec<_>>();
+        qualified_dealers.sort_unstable();
         if qualified_dealers.len() < usize::from(self.params.threshold) {
             eyre::bail!("cannot finalize with fewer than the threshold qualified parties");
         }
@@ -427,6 +434,7 @@ impl<C: CurveGroup> BlameRound<C> {
                 sk_share: my_secret_key_share,
                 pk_shares: public_key_shares,
                 pk: public_key.into_affine(),
+                contributing_parties: qualified_dealers,
             },
             disqualified_parties: self.disqualified_dealers.into_iter().collect(),
             excluded_verdict_parties: Vec::new(),

--- a/threshold-eddsa-babyjubjub/src/keygen/blame.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/blame.rs
@@ -8,7 +8,7 @@ use crate::{
     keygen::{Parameters, SecretScalars, finished::Finished, round2::RoundTwo},
     shamir::utils,
 };
-use ark_ec::{AffineRepr, CurveGroup};
+use ark_ec::CurveGroup;
 use ark_ff::Zero;
 use eyre::Result;
 use serde::{Deserialize, Serialize};
@@ -58,20 +58,6 @@ pub struct BlameResult<C: CurveGroup> {
     pub finished: Finished<C>,
     /// Dealers identified by invalid, malformed, or missing revelations.
     pub disqualified_parties: Vec<u16>,
-}
-
-impl<C: CurveGroup> BlameResult<C> {
-    /// Return every disqualified party together with its default public-key share.
-    ///
-    /// Disqualified parties are inactive in the finalized sharing and therefore have the identity
-    /// point as their entry in [`Finished::pk_shares`].
-    #[must_use]
-    pub fn disqualified_public_key_shares(&self) -> BTreeMap<u16, C::Affine> {
-        self.disqualified_parties
-            .iter()
-            .map(|party| (*party, self.finished.pk_shares[party]))
-            .collect()
-    }
 }
 
 /// State for the optional public DKG complaint and blame workflow.
@@ -257,8 +243,7 @@ impl<C: CurveGroup> BlameRound<C> {
     /// Returns an error if verdict collection is incomplete, the dealer was not accused, or its
     /// accusation was already resolved.
     pub fn disqualify_missing_dealer(&mut self, dealer: u16) -> Result<()> {
-        let accusations = self.accusations()?;
-        if !accusations.contains_key(&dealer) {
+        if !self.accusations()?.contains_key(&dealer) {
             eyre::bail!("party {dealer} was not accused");
         }
         if !self.resolved_dealers.insert(dealer) {
@@ -287,10 +272,9 @@ impl<C: CurveGroup> BlameRound<C> {
     /// Returns an error until every verdict and required revelation has been processed, or if all
     /// dealers were disqualified.
     pub fn finalize(self) -> Result<BlameResult<C>> {
-        // The following is performed in accusations, which is called in missing_revelations
-        // if !self.verdicts_complete() {
-        //     eyre::bail!("cannot finalize before all verdicts are received");
-        // }
+        if !self.verdicts_complete() {
+            eyre::bail!("cannot finalize before all verdicts are received");
+        }
         if !self.missing_revelations()?.is_empty() {
             eyre::bail!("cannot finalize before all accusations are resolved");
         }
@@ -316,20 +300,18 @@ impl<C: CurveGroup> BlameRound<C> {
                     }
                 });
         let mut public_key_shares = HashMap::new();
-        for party in 1..=self.params.number_of_parties {
-            let share = if self.disqualified_dealers.contains(&party) {
-                C::Affine::zero()
-            } else {
-                qualified_dealers
-                    .iter()
-                    .fold(C::zero(), |acc, dealer| {
-                        acc + utils::evaluate_polynomial_in_exponent::<C>(
-                            &self.commitments[dealer],
-                            party,
-                        )
-                    })
-                    .into_affine()
-            };
+        for party in (1..=self.params.number_of_parties)
+            .filter(|party| !self.disqualified_dealers.contains(party))
+        {
+            let share = qualified_dealers
+                .iter()
+                .fold(C::zero(), |acc, dealer| {
+                    acc + utils::evaluate_polynomial_in_exponent::<C>(
+                        &self.commitments[dealer],
+                        party,
+                    )
+                })
+                .into_affine();
             public_key_shares.insert(party, share);
         }
         let public_key = qualified_dealers

--- a/threshold-eddsa-babyjubjub/src/keygen/finished.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/finished.rs
@@ -1,0 +1,24 @@
+//! The final state of the DKG protocol.
+//!
+//! This module defines the `Finished` struct, which holds one party's share of the jointly
+//! generated signing key together with the public information about all parties.
+
+use ark_ec::CurveGroup;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// The state of the DKG protocol after it has finished, holding the results of the protocol.
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "Only carries the results of the protocol - not planned to add something"
+)]
+pub struct Finished<C: CurveGroup> {
+    /// The session id shared by all parties of this protocol run.
+    pub session_id: Uuid,
+    /// This party's Shamir share of the jointly generated signing key.
+    pub sk_share: C::ScalarField,
+    /// The public counterparts of the secret key shares of all parties, indexed by party index.
+    pub pk_shares: HashMap<u16, C::Affine>,
+    /// The public key belonging to the jointly generated signing key.
+    pub pk: C::Affine,
+}

--- a/threshold-eddsa-babyjubjub/src/keygen/finished.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/finished.rs
@@ -4,11 +4,25 @@
 //! generated signing key together with the public information about all parties.
 
 use ark_ec::CurveGroup;
+use ark_serialize::CanonicalSerialize;
 use std::collections::HashMap;
 use uuid::Uuid;
 use zeroize::Zeroize;
 
+const AGREEMENT_DIGEST_LABEL: &[u8] = b"TACEO_THRESHOLD_EDDSA_AGREEMENT_V1";
+
 /// The state of the DKG protocol after it has finished, holding the results of the protocol.
+///
+/// Every field except [`Finished::my_idx`] and [`Finished::sk_share`] must be identical at every
+/// honest participant; [`Finished::agreement_digest`] reduces those to one comparable value.
+///
+/// There is deliberately no conversion to [`DLogShareShamir`](crate::shamir::secret::DLogShareShamir),
+/// because this type does not carry the [`Parameters`](crate::keygen::Parameters) of the run. The
+/// caller must pass the party count and threshold itself, and a wrong-but-self-consistent value is
+/// accepted silently: `sign_round` derives the Lagrange coefficient from the signer set, so a too
+/// small threshold only loosens the minimum-signer-set check and a too large party count only
+/// loosens the range check. Neither enables a forgery, but neither is caught either. After a reshare,
+/// pass the *new* parameters.
 #[expect(
     clippy::exhaustive_structs,
     reason = "Only carries the results of the protocol - not planned to add something"
@@ -24,6 +38,67 @@ pub struct Finished<C: CurveGroup> {
     pub pk_shares: HashMap<u16, C::Affine>,
     /// The public key belonging to the jointly generated signing key.
     pub pk: C::Affine,
+    /// The parties whose polynomial contributions make up this output, ascending.
+    ///
+    /// For a DKG these are the qualified dealers, in the same index namespace as
+    /// [`Finished::pk_shares`]. For a reshare these are the surviving *old* senders, so they are
+    /// **old**-committee indices while `pk_shares` is keyed by new-party index.
+    pub contributing_parties: Vec<u16>,
+}
+
+impl<C: CurveGroup> Finished<C> {
+    /// A digest over everything in this output that all participants must agree on: the session id,
+    /// [`Finished::contributing_parties`], [`Finished::pk`], and [`Finished::pk_shares`]. The
+    /// per-party `my_idx` and `sk_share` are excluded, so an honest run yields the same digest
+    /// everywhere.
+    ///
+    /// Comparing this is mandatory after a reshare. Resharing combines the surviving senders as
+    /// `P_S(Z) = Σ_{i∈S} λ_i^S · f_i(Z)`, and every coefficient depends on `S` — but `P_S(0) = sk`
+    /// for *every* valid `S`. Receivers that disagreed on `S` hold points on unrelated polynomials
+    /// while both reconstruct the correct public key, so the public-key check in `finalize` reports
+    /// nothing and the shares silently fail to interpolate. The DKG has no such blind spot: there a
+    /// divergent dealer set changes `pk` itself. Compare digests before erasing the old shares.
+    #[must_use]
+    pub fn agreement_digest(&self) -> [u8; 32] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(AGREEMENT_DIGEST_LABEL);
+        hasher.update(self.session_id.as_bytes());
+
+        // Both collections are variable-length, so length-prefix them to keep the preimage injective.
+        hasher.update(&length_prefix(self.contributing_parties.len()));
+        for party in &self.contributing_parties {
+            hasher.update(&party.to_be_bytes());
+        }
+
+        let mut buf = Vec::new();
+        absorb_point::<C>(&mut hasher, &mut buf, &self.pk);
+
+        // `pk_shares` is a `HashMap`, so absorb a sorted index list: the digest must not depend on
+        // hash order.
+        let mut indices = self.pk_shares.keys().copied().collect::<Vec<_>>();
+        indices.sort_unstable();
+        hasher.update(&length_prefix(indices.len()));
+        for index in indices {
+            hasher.update(&index.to_be_bytes());
+            absorb_point::<C>(&mut hasher, &mut buf, &self.pk_shares[&index]);
+        }
+
+        *hasher.finalize().as_bytes()
+    }
+}
+
+fn absorb_point<C: CurveGroup>(hasher: &mut blake3::Hasher, buf: &mut Vec<u8>, point: &C::Affine) {
+    point
+        .serialize_compressed(&mut *buf)
+        .expect("can serialize a curve point into a vec");
+    hasher.update(buf);
+    buf.clear();
+}
+
+fn length_prefix(length: usize) -> [u8; 8] {
+    u64::try_from(length)
+        .expect("participant-sized length fits into u64")
+        .to_be_bytes()
 }
 
 impl<C: CurveGroup> Drop for Finished<C> {

--- a/threshold-eddsa-babyjubjub/src/keygen/finished.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/finished.rs
@@ -6,6 +6,7 @@
 use ark_ec::CurveGroup;
 use std::collections::HashMap;
 use uuid::Uuid;
+use zeroize::Zeroize;
 
 /// The state of the DKG protocol after it has finished, holding the results of the protocol.
 #[expect(
@@ -23,4 +24,10 @@ pub struct Finished<C: CurveGroup> {
     pub pk_shares: HashMap<u16, C::Affine>,
     /// The public key belonging to the jointly generated signing key.
     pub pk: C::Affine,
+}
+
+impl<C: CurveGroup> Drop for Finished<C> {
+    fn drop(&mut self) {
+        self.sk_share.zeroize();
+    }
 }

--- a/threshold-eddsa-babyjubjub/src/keygen/finished.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/finished.rs
@@ -13,6 +13,8 @@ use uuid::Uuid;
     reason = "Only carries the results of the protocol - not planned to add something"
 )]
 pub struct Finished<C: CurveGroup> {
+    /// The index of this party in the set of parties participating in the protocol.
+    pub my_idx: u16,
     /// The session id shared by all parties of this protocol run.
     pub session_id: Uuid,
     /// This party's Shamir share of the jointly generated signing key.

--- a/threshold-eddsa-babyjubjub/src/keygen/mod.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/mod.rs
@@ -10,7 +10,32 @@ pub mod schnorr;
 #[cfg(test)]
 pub mod test;
 
+use ark_ff::PrimeField;
 use serde::{Deserialize, Serialize};
+use std::ops::{Deref, DerefMut};
+use zeroize::Zeroize;
+
+pub(crate) struct SecretScalars<F: PrimeField>(pub(crate) Vec<F>);
+
+impl<F: PrimeField> Deref for SecretScalars<F> {
+    type Target = [F];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<F: PrimeField> DerefMut for SecretScalars<F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<F: PrimeField> Drop for SecretScalars<F> {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
 
 /// The parameters of a DKG protocol run, which must be the same for all participating parties.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -24,9 +49,11 @@ impl Parameters {
     /// `threshold` parties are required to reconstruct the key.
     ///
     /// # Panics
-    /// Panics if `threshold` is larger than `number_of_parties`.
+    /// Panics unless `1 <= threshold <= number_of_parties`.
     #[must_use]
     pub fn new(number_of_parties: u16, threshold: u16) -> Self {
+        assert!(number_of_parties > 0, "Number of parties must be non-zero");
+        assert!(threshold > 0, "Threshold must be non-zero");
         assert!(
             threshold <= number_of_parties,
             "Threshold must not be larger than the number of parties"

--- a/threshold-eddsa-babyjubjub/src/keygen/mod.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/mod.rs
@@ -107,6 +107,12 @@ impl Parameters {
     /// Create the parameters for a protocol run with `number_of_parties` parties, where
     /// `threshold` parties are required to reconstruct the key.
     ///
+    /// `threshold` is the number of shares that reconstruct, so the polynomial has degree
+    /// `threshold - 1`. The `PedPoP` schemes in the [source
+    /// documentation](https://github.com/TaceoLabs/oprf-service/tree/main/docs) use `t` for the
+    /// polynomial *degree* instead, so passing that document's `t` here builds a `(t + 1)`-of-`n`
+    /// key: a valid key that verifies, but a stricter policy than intended.
+    ///
     /// # Panics
     /// Panics unless `1 <= threshold <= number_of_parties`.
     #[must_use]
@@ -131,11 +137,11 @@ impl Parameters {
     }
 }
 
-/// The error returned by a round of the DKG protocol if a party contributed a malformed message.
+/// A party failed a cryptographic check and is provably at fault.
 ///
-/// Carries the ID of the party identified as cheating.
+/// The ID is part of the `Display` output, so attribution survives being logged as a string.
 #[derive(Debug, thiserror::Error)]
-#[error("Malicious parties detected")]
+#[error("party {0} failed a cryptographic check and is provably at fault")]
 pub struct MaliciousPartyError(usize);
 
 impl MaliciousPartyError {
@@ -152,12 +158,12 @@ impl MaliciousPartyError {
     }
 }
 
-/// The error returned by the first round of the DKG protocol if two parties broadcast the same
-/// commitment to the constant term of their polynomial.
+/// Two parties broadcast the same commitment to the constant term of their polynomial.
 ///
-/// Carries the IDs of both parties involved.
+/// Both IDs are in the `Display` output. Resolve by passing both to
+/// [`disqualify_parties`](crate::keygen::round1::RoundOne::disqualify_parties) as one atomic set.
 #[derive(Debug, thiserror::Error)]
-#[error("Duplicate commitments detected")]
+#[error("parties {} and {} committed to the same constant term; both are at fault", .0.0, .0.1)]
 pub struct DuplicateCommitmentsError((usize, usize));
 
 impl DuplicateCommitmentsError {
@@ -173,3 +179,77 @@ impl DuplicateCommitmentsError {
         Self((party_id1, party_id2))
     }
 }
+
+/// A message does not fit the local protocol view, which does **not** prove the sender misbehaved.
+///
+/// The usual cause is a configuration mismatch: a node started with different [`Parameters`] derives
+/// a different proof-of-possession context and expects a different commitment count, so every honest
+/// peer looks wrong to it. A stale session ID behaves the same way. Check the local configuration
+/// before excluding the named party.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "message from party {party} does not fit the local protocol view ({reason}); this is usually a \
+     local configuration mismatch and does not prove party {party} misbehaved"
+)]
+pub struct MalformedMessageError {
+    party: usize,
+    reason: &'static str,
+}
+
+impl MalformedMessageError {
+    /// Creates the error naming the claimed sender and why its message did not fit.
+    #[must_use]
+    pub fn new(party: usize, reason: &'static str) -> Self {
+        Self { party, reason }
+    }
+
+    /// The claimed sender. This party is *not* accused; see the type documentation.
+    #[must_use]
+    pub fn party_id(&self) -> usize {
+        self.party
+    }
+}
+
+/// Why a participant's protocol message was rejected.
+///
+/// Only [`MessageError::MaliciousParty`] and [`MessageError::DuplicateCommitments`] attribute blame.
+/// [`MessageError::Malformed`] usually means the *local* node is misconfigured, and
+/// [`MessageError::LocalFault`] means the caller misused the API, so no remote message was evaluated.
+/// Use [`MessageError::attributable_parties`] to act on blame; every variant names the parties
+/// involved in its `Display` output, so a log line is still useful.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum MessageError {
+    /// A cryptographic check failed, so the named sender is provably at fault.
+    #[error(transparent)]
+    MaliciousParty(#[from] MaliciousPartyError),
+    /// Two named parties committed to the same constant term, so both are at fault.
+    #[error(transparent)]
+    DuplicateCommitments(#[from] DuplicateCommitmentsError),
+    /// The message does not fit the local protocol view; blame is not attributable.
+    #[error(transparent)]
+    Malformed(#[from] MalformedMessageError),
+    /// The local caller supplied invalid input, so no remote message was evaluated.
+    #[error(transparent)]
+    LocalFault(#[from] eyre::Report),
+}
+
+impl MessageError {
+    /// Wraps a local-fault message.
+    pub(crate) fn local(reason: String) -> Self {
+        Self::LocalFault(eyre::eyre!(reason))
+    }
+
+    /// The parties this error proves are at fault, empty when it attributes no blame.
+    #[must_use]
+    pub fn attributable_parties(&self) -> Vec<usize> {
+        match self {
+            Self::MaliciousParty(error) => vec![error.0],
+            Self::DuplicateCommitments(error) => vec![error.0.0, error.0.1],
+            Self::Malformed(_) | Self::LocalFault(_) => Vec::new(),
+        }
+    }
+}
+
+/// A [`Result`] whose error separates attributable misbehaviour from a local fault.
+pub type MessageResult<T> = Result<T, MessageError>;

--- a/threshold-eddsa-babyjubjub/src/keygen/mod.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/mod.rs
@@ -1,0 +1,86 @@
+//! Distributed Key Generation for Threshold `EdDSA`
+//!
+//! This module implements the distributed key generation (DKG) protocol that produces the
+//! Shamir shares of the signing key, without any party ever learning the key itself.
+
+pub mod finished;
+pub mod round1;
+pub mod round2;
+pub mod schnorr;
+#[cfg(test)]
+pub mod test;
+
+/// The parameters of a DKG protocol run, which must be the same for all participating parties.
+pub struct Parameters {
+    pub(crate) number_of_parties: u16,
+    pub(crate) threshold: u16,
+}
+
+impl Parameters {
+    /// Create the parameters for a protocol run with `number_of_parties` parties, where
+    /// `threshold` parties are required to reconstruct the key.
+    ///
+    /// # Panics
+    /// Panics if `threshold` is larger than `number_of_parties`.
+    #[must_use]
+    pub fn new(number_of_parties: u16, threshold: u16) -> Self {
+        assert!(
+            threshold <= number_of_parties,
+            "Threshold must not be larger than the number of parties"
+        );
+        Self {
+            number_of_parties,
+            threshold,
+        }
+    }
+
+    /// Returns the degree of the polynomials the parties share their contribution with, i.e., one
+    /// less than the threshold.
+    #[must_use]
+    pub fn degree(&self) -> u16 {
+        self.threshold - 1
+    }
+}
+
+/// The error returned by a round of the DKG protocol if a party contributed a malformed message.
+///
+/// Carries the ID of the party identified as cheating.
+#[derive(Debug, thiserror::Error)]
+#[error("Malicious parties detected")]
+pub struct MaliciousPartyError(usize);
+
+impl MaliciousPartyError {
+    /// Consumes the error and returns the ID of the parties identified as cheating.
+    #[must_use]
+    pub fn into_inner(self) -> usize {
+        self.0
+    }
+
+    /// Creates the error carrying the ID of the party identified as cheating.
+    #[must_use]
+    pub fn new(party_id: usize) -> Self {
+        Self(party_id)
+    }
+}
+
+/// The error returned by the first round of the DKG protocol if two parties broadcast the same
+/// commitment to the constant term of their polynomial.
+///
+/// Carries the IDs of both parties involved.
+#[derive(Debug, thiserror::Error)]
+#[error("Duplicate commitments detected")]
+pub struct DuplicateCommitmentsError((usize, usize));
+
+impl DuplicateCommitmentsError {
+    /// Consumes the error and returns the ID of the parties identified as cheating.
+    #[must_use]
+    pub fn into_inner(self) -> (usize, usize) {
+        self.0
+    }
+
+    /// Creates the error carrying the IDs of the two parties that committed to the same value.
+    #[must_use]
+    pub fn new(party_id1: usize, party_id2: usize) -> Self {
+        Self((party_id1, party_id2))
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/keygen/mod.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/mod.rs
@@ -10,7 +10,10 @@ pub mod schnorr;
 #[cfg(test)]
 pub mod test;
 
+use serde::{Deserialize, Serialize};
+
 /// The parameters of a DKG protocol run, which must be the same for all participating parties.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Parameters {
     pub(crate) number_of_parties: u16,
     pub(crate) threshold: u16,

--- a/threshold-eddsa-babyjubjub/src/keygen/mod.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/mod.rs
@@ -12,8 +12,11 @@ pub mod schnorr;
 pub mod test;
 
 use ark_ff::PrimeField;
-use serde::{Deserialize, Serialize};
-use std::ops::{Deref, DerefMut};
+use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+};
 use zeroize::Zeroize;
 
 pub(crate) struct SecretScalars<F: PrimeField>(pub(crate) Vec<F>);
@@ -38,11 +41,66 @@ impl<F: PrimeField> Drop for SecretScalars<F> {
     }
 }
 
+pub(crate) struct SecretScalarMap<F: PrimeField>(pub(crate) HashMap<u16, F>);
+
+impl<F: PrimeField> Deref for SecretScalarMap<F> {
+    type Target = HashMap<u16, F>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<F: PrimeField> DerefMut for SecretScalarMap<F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<F: PrimeField> Drop for SecretScalarMap<F> {
+    #[allow(
+        clippy::iter_over_hash_type,
+        reason = "zeroization order has no semantic effect"
+    )]
+    fn drop(&mut self) {
+        for value in self.0.values_mut() {
+            value.zeroize();
+        }
+    }
+}
+
 /// The parameters of a DKG protocol run, which must be the same for all participating parties.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct Parameters {
     pub(crate) number_of_parties: u16,
     pub(crate) threshold: u16,
+}
+
+impl<'de> Deserialize<'de> for Parameters {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Repr {
+            number_of_parties: u16,
+            threshold: u16,
+        }
+
+        let repr = Repr::deserialize(deserializer)?;
+        if repr.number_of_parties == 0 {
+            return Err(D::Error::custom("number of parties must be non-zero"));
+        }
+        if repr.threshold == 0 || repr.threshold > repr.number_of_parties {
+            return Err(D::Error::custom(
+                "threshold must be non-zero and not exceed the number of parties",
+            ));
+        }
+        Ok(Self {
+            number_of_parties: repr.number_of_parties,
+            threshold: repr.threshold,
+        })
+    }
 }
 
 impl Parameters {

--- a/threshold-eddsa-babyjubjub/src/keygen/mod.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/mod.rs
@@ -3,6 +3,7 @@
 //! This module implements the distributed key generation (DKG) protocol that produces the
 //! Shamir shares of the signing key, without any party ever learning the key itself.
 
+pub mod blame;
 pub mod finished;
 pub mod round1;
 pub mod round2;

--- a/threshold-eddsa-babyjubjub/src/keygen/round1.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/round1.rs
@@ -17,7 +17,7 @@ use ark_serialize::CompressedChecked;
 use eyre::Result;
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use uuid::Uuid;
 
 /// The state of the DKG protocol in the first round.
@@ -139,7 +139,7 @@ impl<C: CurveGroup> RoundOne<C> {
         }
 
         if self.session_id != comm.session_id {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
+            eyre::bail!("session id mismatch for party {from}");
         }
 
         // verify ZK proof
@@ -208,6 +208,7 @@ impl<C: CurveGroup> RoundOne<C> {
         Ok(RoundTwo {
             session_id: self.session_id,
             received_party_messages: HashMap::with_capacity(commitments.len() - 1),
+            failed_parties: BTreeSet::default(),
             commitments,
             secret_shares: SecretScalars(secret_shares),
             my_idx: self.my_idx,

--- a/threshold-eddsa-babyjubjub/src/keygen/round1.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/round1.rs
@@ -37,11 +37,10 @@ pub struct RoundOne<C: CurveGroup> {
 /// Communication sent in the first round of the DKG protocol.
 /// This is intended to be broadcast to all other participants.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound = "")] // we need this to fix serde's assumptions about nizk
 pub struct RoundOneBroadcast<C: CurveGroup> {
-    session_id: Uuid,
-    commitments: CompressedChecked<Vec<C::Affine>>,
-    nizk: SchnorrZkProof<C>,
+    pub(crate) session_id: Uuid,
+    pub(crate) commitments: CompressedChecked<Vec<C::Affine>>,
+    pub(crate) nizk: SchnorrZkProof<C>,
 }
 
 impl<C: CurveGroup> RoundOne<C> {
@@ -120,7 +119,7 @@ impl<C: CurveGroup> RoundOne<C> {
         }
 
         if self.received_party_messages.contains_key(&from) {
-            eyre::bail!("already added message for party {from}",);
+            eyre::bail!("already added message for party {from}");
         }
         if comm.commitments.len() != usize::from(self.params.threshold) {
             eyre::bail!(MaliciousPartyError::new(from as usize));
@@ -181,10 +180,7 @@ impl<C: CurveGroup> RoundOne<C> {
         // evaluate our polynomial to get the secret share of each party
         let secret_shares = (1..=self.params.number_of_parties)
             .map(|party_idx| {
-                utils::evaluate_poly(
-                    &self.coefficients,
-                    C::ScalarField::from(u64::from(party_idx)),
-                )
+                utils::evaluate_poly(&self.coefficients, C::ScalarField::from(party_idx))
             })
             .collect();
 

--- a/threshold-eddsa-babyjubjub/src/keygen/round1.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/round1.rs
@@ -5,7 +5,8 @@
 
 use crate::{
     keygen::{
-        DuplicateCommitmentsError, MaliciousPartyError, Parameters, SecretScalarMap, SecretScalars,
+        DuplicateCommitmentsError, MalformedMessageError, MaliciousPartyError, MessageError,
+        MessageResult, Parameters, SecretScalarMap, SecretScalars,
         round2::RoundTwo,
         schnorr::{self, SchnorrZkProof},
     },
@@ -13,7 +14,6 @@ use crate::{
 };
 use ark_ec::CurveGroup;
 use ark_ff::UniformRand;
-use ark_serialize::CompressedChecked;
 use eyre::Result;
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
@@ -39,9 +39,14 @@ pub struct RoundOne<C: CurveGroup> {
 /// Communication sent in the first round of the DKG protocol.
 /// This is intended to be broadcast to all other participants.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound(serialize = "", deserialize = ""))]
 pub struct RoundOneBroadcast<C: CurveGroup> {
     pub(crate) session_id: Uuid,
-    pub(crate) commitments: CompressedChecked<Vec<C::Affine>>,
+    #[serde(
+        serialize_with = "crate::serde_utils::serialize_canonical_protocol_vec",
+        deserialize_with = "crate::serde_utils::deserialize_canonical_protocol_vec"
+    )]
+    pub(crate) commitments: Vec<C::Affine>,
     pub(crate) nizk: SchnorrZkProof<C>,
 }
 
@@ -51,7 +56,12 @@ impl<C: CurveGroup> RoundOne<C> {
     /// Begin a new instance of the distributed key generation protocol.
     /// The provided [`Parameters`] must be the same for all participating parties.
     /// Each party must have a distinct `party_index`, ranging from 1 to `params.number_of_parties`, inclusively.
-    /// The provided session id must be the same for all participating parties.
+    /// The provided session id must be the same for all participating parties, and must be globally
+    /// unique per run: it is the only run-specific input to the proof-of-possession context, so
+    /// reusing it with the same [`Parameters`] makes round-one broadcasts replayable. An adversary
+    /// with network control can then suppress an honest party's fresh broadcast, inject its stale
+    /// one, and have the honest party's fresh evaluations fail against the stale commitments — which
+    /// gets it blamed. Use a fresh [`Uuid::new_v4`] per run, never an id derived from configuration.
     ///
     /// # Errors
     /// Returns an error if `party_index` is zero or larger than the number of parties allowed by
@@ -108,7 +118,7 @@ impl<C: CurveGroup> RoundOne<C> {
     pub fn get_broadcast_message(&self) -> RoundOneBroadcast<C> {
         RoundOneBroadcast {
             session_id: self.session_id,
-            commitments: CompressedChecked(self.commitments.clone()),
+            commitments: self.commitments.clone(),
             nizk: self.nizk.clone(),
         }
     }
@@ -116,32 +126,52 @@ impl<C: CurveGroup> RoundOne<C> {
     /// Add a [`RoundOneBroadcast`] received from a party, verifying that everything is in order.
     ///
     /// # Errors
-    /// Returns a [`MaliciousPartyError`] identifying the offending party if its broadcast contains
-    /// the wrong number of commitments, a different session id, or an invalid proof of knowledge.
-    /// Returns a [`DuplicateCommitmentsError`] identifying both offending parties if this party
-    /// committed to the same constant term as a party added earlier.
-    /// All other errors indicate an invalid `from` index and are usually the fault of the local
-    /// party.
-    pub fn add_party_communication(&mut self, from: u16, comm: RoundOneBroadcast<C>) -> Result<()> {
+    /// Returns [`MessageError::MaliciousParty`] for an invalid proof of knowledge and
+    /// [`MessageError::DuplicateCommitments`] if this broadcast repeats the constant-term commitment
+    /// of the local party or of one added earlier; both attribute blame.
+    /// [`MessageError::Malformed`] (wrong commitment count or session id) does not — it is usually a
+    /// local configuration mismatch. [`MessageError::LocalFault`] means an invalid `from` index or a
+    /// duplicate delivery.
+    pub fn add_party_communication(
+        &mut self,
+        from: u16,
+        comm: RoundOneBroadcast<C>,
+    ) -> MessageResult<()> {
         if from == 0 {
-            eyre::bail!("party index must be non-zero",);
+            return Err(MessageError::local(
+                "party index must be non-zero".to_owned(),
+            ));
         }
         if from > self.params.number_of_parties {
-            eyre::bail!("party index {from} invalid for parameters",);
+            return Err(MessageError::local(format!(
+                "party index {from} invalid for parameters"
+            )));
         }
         if from == self.my_idx {
-            eyre::bail!("do not add messages from own party {from}",);
+            return Err(MessageError::local(format!(
+                "do not add messages from own party {from}"
+            )));
         }
 
         if self.received_party_messages.contains_key(&from) {
-            eyre::bail!("already added message for party {from}");
+            return Err(MessageError::local(format!(
+                "already added message for party {from}"
+            )));
         }
         if comm.commitments.len() != usize::from(self.params.threshold) {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
+            return Err(MalformedMessageError::new(
+                from as usize,
+                "commitment count does not match the local threshold",
+            )
+            .into());
         }
 
         if self.session_id != comm.session_id {
-            eyre::bail!("session id mismatch for party {from}");
+            return Err(MalformedMessageError::new(
+                from as usize,
+                "session id does not match the local session",
+            )
+            .into());
         }
 
         // verify ZK proof
@@ -150,29 +180,25 @@ impl<C: CurveGroup> RoundOne<C> {
             .nizk
             .verify(&context, from, &comm.commitments[0], &comm.commitments[1..])
         {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
+            return Err(MaliciousPartyError::new(from as usize).into());
         }
 
         // the commitment to the constant term must be unique across parties, so a duplicate means
         // one party copied the other and both are reported as offending
         let share_commitment = &comm.commitments[0];
         if share_commitment == &self.commitments[0] {
-            eyre::bail!(DuplicateCommitmentsError::new(
-                from as usize,
-                self.my_idx as usize,
-            ));
+            return Err(DuplicateCommitmentsError::new(from as usize, self.my_idx as usize).into());
         }
         for id in 1..=self.params.number_of_parties {
             let Some(commitment) = self.received_party_messages.get(&id) else {
                 continue;
             };
             if share_commitment == &commitment[0] {
-                eyre::bail!(DuplicateCommitmentsError::new(from as usize, id as usize));
+                return Err(DuplicateCommitmentsError::new(from as usize, id as usize).into());
             }
         }
 
-        self.received_party_messages
-            .insert(from, comm.commitments.0);
+        self.received_party_messages.insert(from, comm.commitments);
 
         Ok(())
     }

--- a/threshold-eddsa-babyjubjub/src/keygen/round1.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/round1.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     keygen::{
-        DuplicateCommitmentsError, MaliciousPartyError, Parameters, SecretScalars,
+        DuplicateCommitmentsError, MaliciousPartyError, Parameters, SecretScalarMap, SecretScalars,
         round2::RoundTwo,
         schnorr::{self, SchnorrZkProof},
     },
@@ -33,6 +33,7 @@ pub struct RoundOne<C: CurveGroup> {
     my_idx: u16,
     params: Parameters,
     received_party_messages: HashMap<u16, Vec<C::Affine>>,
+    disqualified_parties: BTreeSet<u16>,
 }
 
 /// Communication sent in the first round of the DKG protocol.
@@ -99,6 +100,7 @@ impl<C: CurveGroup> RoundOne<C> {
             params: parameters,
             session_id,
             received_party_messages: HashMap::with_capacity(num_parties as usize - 1),
+            disqualified_parties: BTreeSet::new(),
         })
     }
 
@@ -154,6 +156,12 @@ impl<C: CurveGroup> RoundOne<C> {
         // the commitment to the constant term must be unique across parties, so a duplicate means
         // one party copied the other and both are reported as offending
         let share_commitment = &comm.commitments[0];
+        if share_commitment == &self.commitments[0] {
+            eyre::bail!(DuplicateCommitmentsError::new(
+                from as usize,
+                self.my_idx as usize,
+            ));
+        }
         for id in 1..=self.params.number_of_parties {
             let Some(commitment) = self.received_party_messages.get(&id) else {
                 continue;
@@ -174,21 +182,76 @@ impl<C: CurveGroup> RoundOne<C> {
         (1..=self.params.number_of_parties)
             .filter(|idx| *idx != self.my_idx)
             .filter(|idx| !self.received_party_messages.contains_key(idx))
+            .filter(|idx| !self.disqualified_parties.contains(idx))
             .collect()
+    }
+
+    /// Record an externally agreed disqualification for a missing or malformed round-one dealer.
+    ///
+    /// Every honest participant must apply the same decision, normally after reliable broadcast
+    /// or a common timeout certificate.
+    ///
+    /// An accepted broadcast is removed so every honest participant can apply the same qualified
+    /// set even if duplicate commitments were received in different orders. If `party` is the
+    /// local party, this state becomes terminal and [`RoundOne::round2`] will reject it.
+    ///
+    /// # Errors
+    /// Returns an error for an invalid or already-disqualified party.
+    pub fn disqualify_party(&mut self, party: u16) -> Result<()> {
+        self.disqualify_parties(&BTreeSet::from([party]))
+    }
+
+    /// Atomically apply an externally agreed set of round-one disqualifications.
+    ///
+    /// This is the preferred API for resolving [`DuplicateCommitmentsError`], which identifies
+    /// both dealers. Every honest participant must apply the same complete set.
+    ///
+    /// # Errors
+    /// Returns an error without changing state if the set is empty, contains an invalid party, or
+    /// contains a party that was already disqualified, or would leave fewer than the threshold
+    /// number of qualified parties.
+    pub fn disqualify_parties(&mut self, parties: &BTreeSet<u16>) -> Result<()> {
+        if parties.is_empty() {
+            eyre::bail!("at least one round-one party must be disqualified");
+        }
+        for party in parties {
+            if *party == 0 || *party > self.params.number_of_parties {
+                eyre::bail!("invalid round-one party to disqualify: {party}");
+            }
+            if self.disqualified_parties.contains(party) {
+                eyre::bail!("party {party} was already disqualified");
+            }
+        }
+        let remaining = usize::from(self.params.number_of_parties)
+            - self.disqualified_parties.len()
+            - parties.len();
+        if remaining < usize::from(self.params.threshold) {
+            eyre::bail!("round-one disqualifications would leave fewer than the threshold parties");
+        }
+        for party in parties {
+            self.received_party_messages.remove(party);
+            self.disqualified_parties.insert(*party);
+        }
+        Ok(())
     }
 
     /// Indicates if all required messages have been received and we can proceed to the next round.
     /// See [`RoundOne::get_missing_parties`] to retrieve a list of parties we are still waiting on.
     pub fn can_advance(&self) -> bool {
-        self.received_party_messages.len() == usize::from(self.params.number_of_parties) - 1
+        !self.disqualified_parties.contains(&self.my_idx)
+            && self.received_party_messages.len() + self.disqualified_parties.len()
+                == usize::from(self.params.number_of_parties) - 1
     }
 
     /// Try to advance into the second round of the DKG protocol.
     ///
     /// # Errors
     /// Returns an error if not all [`RoundOneBroadcast`] messages have been added yet, i.e., if
-    /// [`RoundOne::can_advance`] returns false.
+    /// [`RoundOne::can_advance`] returns false, or if the local party was disqualified.
     pub fn round2(self) -> Result<RoundTwo<C>> {
+        if self.disqualified_parties.contains(&self.my_idx) {
+            eyre::bail!("local party was disqualified in round one");
+        }
         if !self.can_advance() {
             eyre::bail!("cannot advance to round 2, not all messages received");
         }
@@ -207,8 +270,9 @@ impl<C: CurveGroup> RoundOne<C> {
 
         Ok(RoundTwo {
             session_id: self.session_id,
-            received_party_messages: HashMap::with_capacity(commitments.len() - 1),
+            received_party_messages: SecretScalarMap(HashMap::with_capacity(commitments.len() - 1)),
             failed_parties: BTreeSet::default(),
+            disqualified_parties: self.disqualified_parties,
             commitments,
             secret_shares: SecretScalars(secret_shares),
             my_idx: self.my_idx,

--- a/threshold-eddsa-babyjubjub/src/keygen/round1.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/round1.rs
@@ -5,8 +5,9 @@
 
 use crate::{
     keygen::{
-        DuplicateCommitmentsError, MaliciousPartyError, Parameters, round2::RoundTwo,
-        schnorr::SchnorrZkProof,
+        DuplicateCommitmentsError, MaliciousPartyError, Parameters, SecretScalars,
+        round2::RoundTwo,
+        schnorr::{self, SchnorrZkProof},
     },
     shamir::utils,
 };
@@ -26,7 +27,7 @@ use uuid::Uuid;
 /// same information from all other parties.
 pub struct RoundOne<C: CurveGroup> {
     session_id: Uuid,
-    coefficients: Vec<C::ScalarField>,
+    coefficients: SecretScalars<C::ScalarField>,
     commitments: Vec<C::Affine>,
     nizk: SchnorrZkProof<C>,
     my_idx: u16,
@@ -44,6 +45,8 @@ pub struct RoundOneBroadcast<C: CurveGroup> {
 }
 
 impl<C: CurveGroup> RoundOne<C> {
+    const CONTEXT_DOMAIN: &'static [u8] = b"PEDPOP_DKG_V1";
+
     /// Begin a new instance of the distributed key generation protocol.
     /// The provided [`Parameters`] must be the same for all participating parties.
     /// Each party must have a distinct `party_index`, ranging from 1 to `params.number_of_parties`, inclusively.
@@ -65,16 +68,26 @@ impl<C: CurveGroup> RoundOne<C> {
             eyre::bail!("provided party index {party_index} is larger than parameters allow",);
         }
 
-        let coefficients = (0..=parameters.degree())
-            .map(|_| C::ScalarField::rand(rng))
-            .collect::<Vec<_>>();
+        let coefficients = SecretScalars(
+            (0..=parameters.degree())
+                .map(|_| C::ScalarField::rand(rng))
+                .collect::<Vec<_>>(),
+        );
 
         let commitments = coefficients
             .iter()
             .map(|a_k| (C::generator() * a_k).into_affine())
             .collect::<Vec<_>>();
 
-        let nizk = SchnorrZkProof::<C>::new(party_index, &coefficients[0], &commitments[0], rng);
+        let context = schnorr::proof_context(Self::CONTEXT_DOMAIN, session_id, &[parameters]);
+        let nizk = SchnorrZkProof::<C>::new(
+            &context,
+            party_index,
+            &coefficients[0],
+            &commitments[0],
+            &commitments[1..],
+            rng,
+        );
 
         let num_parties = parameters.number_of_parties;
 
@@ -130,7 +143,11 @@ impl<C: CurveGroup> RoundOne<C> {
         }
 
         // verify ZK proof
-        if !comm.nizk.verify(from, &comm.commitments[0]) {
+        let context = schnorr::proof_context(Self::CONTEXT_DOMAIN, self.session_id, &[self.params]);
+        if !comm
+            .nizk
+            .verify(&context, from, &comm.commitments[0], &comm.commitments[1..])
+        {
             eyre::bail!(MaliciousPartyError::new(from as usize));
         }
 
@@ -192,7 +209,7 @@ impl<C: CurveGroup> RoundOne<C> {
             session_id: self.session_id,
             received_party_messages: HashMap::with_capacity(commitments.len() - 1),
             commitments,
-            secret_shares,
+            secret_shares: SecretScalars(secret_shares),
             my_idx: self.my_idx,
             params: self.params,
         })

--- a/threshold-eddsa-babyjubjub/src/keygen/round1.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/round1.rs
@@ -1,0 +1,204 @@
+//! The first round of the DKG protocol.
+//!
+//! In this round every party commits to the coefficients of its polynomial and broadcasts these
+//! commitments, so that the parties can verify the secret shares they receive in the second round.
+
+use crate::{
+    keygen::{
+        DuplicateCommitmentsError, MaliciousPartyError, Parameters, round2::RoundTwo,
+        schnorr::SchnorrZkProof,
+    },
+    shamir::utils,
+};
+use ark_ec::CurveGroup;
+use ark_ff::UniformRand;
+use ark_serialize::CompressedChecked;
+use eyre::Result;
+use rand::{CryptoRng, Rng};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// The state of the DKG protocol in the first round.
+///
+/// In this round each party samples a random polynomial, publishes the commitments to its
+/// coefficients together with a Schnorr proof of knowledge of the constant term, and collects the
+/// same information from all other parties.
+pub struct RoundOne<C: CurveGroup> {
+    session_id: Uuid,
+    coefficients: Vec<C::ScalarField>,
+    commitments: Vec<C::Affine>,
+    nizk: SchnorrZkProof<C>,
+    my_idx: u16,
+    params: Parameters,
+    received_party_messages: HashMap<u16, Vec<C::Affine>>,
+}
+
+/// Communication sent in the first round of the DKG protocol.
+/// This is intended to be broadcast to all other participants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound = "")] // we need this to fix serde's assumptions about nizk
+pub struct RoundOneBroadcast<C: CurveGroup> {
+    session_id: Uuid,
+    commitments: CompressedChecked<Vec<C::Affine>>,
+    nizk: SchnorrZkProof<C>,
+}
+
+impl<C: CurveGroup> RoundOne<C> {
+    /// Begin a new instance of the distributed key generation protocol.
+    /// The provided [`Parameters`] must be the same for all participating parties.
+    /// Each party must have a distinct `party_index`, ranging from 1 to `params.number_of_parties`, inclusively.
+    /// The provided session id must be the same for all participating parties.
+    ///
+    /// # Errors
+    /// Returns an error if `party_index` is zero or larger than the number of parties allowed by
+    /// the provided [`Parameters`].
+    pub fn new<R: Rng + CryptoRng>(
+        parameters: Parameters,
+        party_index: u16,
+        session_id: Uuid,
+        rng: &mut R,
+    ) -> Result<Self> {
+        if party_index == 0 {
+            eyre::bail!("party index must be non-zero",);
+        }
+        if party_index > parameters.number_of_parties {
+            eyre::bail!("provided party index {party_index} is larger than parameters allow",);
+        }
+
+        let coefficients = (0..=parameters.degree())
+            .map(|_| C::ScalarField::rand(rng))
+            .collect::<Vec<_>>();
+
+        let commitments = coefficients
+            .iter()
+            .map(|a_k| (C::generator() * a_k).into_affine())
+            .collect::<Vec<_>>();
+
+        let nizk = SchnorrZkProof::<C>::new(party_index, &coefficients[0], &commitments[0], rng);
+
+        let num_parties = parameters.number_of_parties;
+
+        Ok(RoundOne {
+            coefficients,
+            commitments,
+            nizk,
+            my_idx: party_index,
+            params: parameters,
+            session_id,
+            received_party_messages: HashMap::with_capacity(num_parties as usize - 1),
+        })
+    }
+
+    /// Returns the message that must be broadcast to all other participants in this round.
+    pub fn get_broadcast_message(&self) -> RoundOneBroadcast<C> {
+        RoundOneBroadcast {
+            session_id: self.session_id,
+            commitments: CompressedChecked(self.commitments.clone()),
+            nizk: self.nizk.clone(),
+        }
+    }
+
+    /// Add a [`RoundOneBroadcast`] received from a party, verifying that everything is in order.
+    ///
+    /// # Errors
+    /// Returns a [`MaliciousPartyError`] identifying the offending party if its broadcast contains
+    /// the wrong number of commitments, a different session id, or an invalid proof of knowledge.
+    /// Returns a [`DuplicateCommitmentsError`] identifying both offending parties if this party
+    /// committed to the same constant term as a party added earlier.
+    /// All other errors indicate an invalid `from` index and are usually the fault of the local
+    /// party.
+    pub fn add_party_communication(&mut self, from: u16, comm: RoundOneBroadcast<C>) -> Result<()> {
+        if from == 0 {
+            eyre::bail!("party index must be non-zero",);
+        }
+        if from > self.params.number_of_parties {
+            eyre::bail!("party index {from} invalid for parameters",);
+        }
+        if from == self.my_idx {
+            eyre::bail!("do not add messages from own party {from}",);
+        }
+
+        if self.received_party_messages.contains_key(&from) {
+            eyre::bail!("already added message for party {from}",);
+        }
+        if comm.commitments.len() != usize::from(self.params.threshold) {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+
+        if self.session_id != comm.session_id {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+
+        // verify ZK proof
+        if !comm.nizk.verify(from, &comm.commitments[0]) {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+
+        // the commitment to the constant term must be unique across parties, so a duplicate means
+        // one party copied the other and both are reported as offending
+        let share_commitment = &comm.commitments[0];
+        for id in 1..=self.params.number_of_parties {
+            let Some(commitment) = self.received_party_messages.get(&id) else {
+                continue;
+            };
+            if share_commitment == &commitment[0] {
+                eyre::bail!(DuplicateCommitmentsError::new(from as usize, id as usize));
+            }
+        }
+
+        self.received_party_messages
+            .insert(from, comm.commitments.0);
+
+        Ok(())
+    }
+
+    /// Returns a list of party indices for which we have not yet received and added a [`RoundOneBroadcast`] message.
+    pub fn get_missing_parties(&self) -> Vec<u16> {
+        (1..=self.params.number_of_parties)
+            .filter(|idx| *idx != self.my_idx)
+            .filter(|idx| !self.received_party_messages.contains_key(idx))
+            .collect()
+    }
+
+    /// Indicates if all required messages have been received and we can proceed to the next round.
+    /// See [`RoundOne::get_missing_parties`] to retrieve a list of parties we are still waiting on.
+    pub fn can_advance(&self) -> bool {
+        self.received_party_messages.len() == usize::from(self.params.number_of_parties) - 1
+    }
+
+    /// Try to advance into the second round of the DKG protocol.
+    ///
+    /// # Errors
+    /// Returns an error if not all [`RoundOneBroadcast`] messages have been added yet, i.e., if
+    /// [`RoundOne::can_advance`] returns false.
+    pub fn round2(self) -> Result<RoundTwo<C>> {
+        if !self.can_advance() {
+            eyre::bail!("cannot advance to round 2, not all messages received");
+        }
+        // at this point, we have already checked that the received values are ok
+
+        // evaluate our polynomial to get the secret share of each party
+        let secret_shares = (1..=self.params.number_of_parties)
+            .map(|party_idx| {
+                utils::evaluate_poly(
+                    &self.coefficients,
+                    C::ScalarField::from(u64::from(party_idx)),
+                )
+            })
+            .collect();
+
+        let mut commitments = self.received_party_messages;
+        // also insert ourself into commitments
+        commitments.insert(self.my_idx, self.commitments);
+
+        Ok(RoundTwo {
+            session_id: self.session_id,
+            received_party_messages: HashMap::with_capacity(commitments.len() - 1),
+            commitments,
+            secret_shares,
+            my_idx: self.my_idx,
+            params: self.params,
+        })
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/keygen/round2.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/round2.rs
@@ -5,8 +5,8 @@
 
 use crate::{
     keygen::{
-        MaliciousPartyError, Parameters, SecretScalarMap, SecretScalars, blame::BlameRound,
-        finished::Finished,
+        MalformedMessageError, MaliciousPartyError, MessageError, MessageResult, Parameters,
+        SecretScalarMap, SecretScalars, blame::BlameRound, finished::Finished,
     },
     shamir::utils,
 };
@@ -56,10 +56,14 @@ impl<C: CurveGroup> RoundTwo<C> {
     /// The message has to be sent using a private communication channel, and should not be available to other parties.
     ///
     /// # Errors
-    /// Returns an error if `for_party` is not a valid party index for the used [`Parameters`].
+    /// Returns an error if `for_party` is not a valid party index for the used [`Parameters`] or
+    /// if that party was disqualified in round one.
     pub fn get_party_communication(&self, for_party: u16) -> Result<RoundTwoCommunication<C>> {
         if for_party == 0 {
             eyre::bail!("party index must be non-zero",);
+        }
+        if self.disqualified_parties.contains(&for_party) {
+            eyre::bail!("party {for_party} was disqualified in round one");
         }
         let idx = usize::from(for_party) - 1;
         let secret_share = *self.secret_shares.get(idx).ok_or(eyre::eyre!(
@@ -75,43 +79,23 @@ impl<C: CurveGroup> RoundTwo<C> {
     /// Add a [`RoundTwoCommunication`] received from a party, verifying that everything is in order.
     ///
     /// # Errors
-    /// Returns a [`MaliciousPartyError`] identifying the offending party if its message carries a
-    /// different session id, or a secret share that does not verify against the commitments this
-    /// party broadcast in the first round.
-    /// All other errors indicate an invalid `from` index and are usually the fault of the local
-    /// party.
+    /// Returns [`MessageError::MaliciousParty`] if the secret share does not verify against the
+    /// commitments the sender broadcast in round one; this attributes blame.
+    /// [`MessageError::Malformed`] (session id mismatch) and [`MessageError::LocalFault`] (invalid
+    /// sender, unqualified dealer, duplicate delivery) do not.
     pub fn add_party_communication(
         &mut self,
         from: u16,
         comm: &RoundTwoCommunication<C>,
-    ) -> Result<()> {
-        if from == 0 {
-            eyre::bail!("party index must be non-zero",);
-        }
-        if from > self.params.number_of_parties {
-            eyre::bail!("party index {from} invalid for parameters",);
-        }
-        if from == self.my_idx {
-            eyre::bail!("do not add messages from own party {from}",);
-        }
-        if !self.commitments.contains_key(&from) {
-            eyre::bail!("party {from} is not a qualified dealer");
-        }
-
-        if self.received_party_messages.contains_key(&from) {
-            eyre::bail!("already added message for party {from}");
-        }
-
-        if self.session_id != comm.session_id {
-            eyre::bail!("session id mismatch for party {from}");
-        }
+    ) -> MessageResult<()> {
+        self.validate_message(from, comm)?;
 
         if !utils::verify_polynomial_evaluation::<C>(
             &self.commitments[&from],
             self.my_idx,
             &comm.secret_share,
         ) {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
+            return Err(MaliciousPartyError::new(from as usize).into());
         }
         self.received_party_messages.insert(from, comm.secret_share);
         Ok(())
@@ -120,36 +104,18 @@ impl<C: CurveGroup> RoundTwo<C> {
     /// Add a private share while retaining malformed shares for the optional public blame round.
     ///
     /// Unlike [`RoundTwo::add_party_communication`], a share that fails its polynomial equation is
-    /// recorded as a complaint rather than returning [`MaliciousPartyError`]. Structural errors,
-    /// duplicate messages, and session mismatches still return an error.
+    /// recorded as a complaint rather than returning [`MessageError::MaliciousParty`]. Structural
+    /// errors, duplicate messages, and session mismatches still return an error.
     ///
     /// # Errors
-    /// Returns an error for an invalid sender, duplicate communication, or mismatched session.
+    /// Returns [`MessageError::Malformed`] for a session mismatch and [`MessageError::LocalFault`]
+    /// for an invalid sender or duplicate communication. Neither attributes blame.
     pub fn add_party_communication_for_blame(
         &mut self,
         from: u16,
         comm: &RoundTwoCommunication<C>,
-    ) -> Result<()> {
-        if from == 0 {
-            eyre::bail!("party index must be non-zero",);
-        }
-        if from > self.params.number_of_parties {
-            eyre::bail!("party index {from} invalid for parameters",);
-        }
-        if from == self.my_idx {
-            eyre::bail!("do not add messages from own party {from}");
-        }
-        if !self.commitments.contains_key(&from) {
-            eyre::bail!("party {from} is not a qualified dealer");
-        }
-
-        if self.received_party_messages.contains_key(&from) {
-            eyre::bail!("already added message for party {from}");
-        }
-
-        if self.session_id != comm.session_id {
-            eyre::bail!("session id mismatch for party {from}");
-        }
+    ) -> MessageResult<()> {
+        self.validate_message(from, comm)?;
 
         if !utils::verify_polynomial_evaluation::<C>(
             &self.commitments[&from],
@@ -159,6 +125,44 @@ impl<C: CurveGroup> RoundTwo<C> {
             self.failed_parties.insert(from);
         }
         self.received_party_messages.insert(from, comm.secret_share);
+        Ok(())
+    }
+
+    /// Checks shared by both intake paths: nothing here inspects the share itself, so no rejection
+    /// attributes blame.
+    fn validate_message(&self, from: u16, comm: &RoundTwoCommunication<C>) -> MessageResult<()> {
+        if from == 0 {
+            return Err(MessageError::local(
+                "party index must be non-zero".to_owned(),
+            ));
+        }
+        if from > self.params.number_of_parties {
+            return Err(MessageError::local(format!(
+                "party index {from} invalid for parameters"
+            )));
+        }
+        if from == self.my_idx {
+            return Err(MessageError::local(format!(
+                "do not add messages from own party {from}"
+            )));
+        }
+        if !self.commitments.contains_key(&from) {
+            return Err(MessageError::local(format!(
+                "party {from} is not a qualified dealer"
+            )));
+        }
+        if self.received_party_messages.contains_key(&from) {
+            return Err(MessageError::local(format!(
+                "already added message for party {from}"
+            )));
+        }
+        if self.session_id != comm.session_id {
+            return Err(MalformedMessageError::new(
+                from as usize,
+                "session id does not match the local session",
+            )
+            .into());
+        }
         Ok(())
     }
 
@@ -242,7 +246,12 @@ impl<C: CurveGroup> RoundTwo<C> {
             .values()
             .fold(C::zero(), |acc, x| acc + x[0]);
 
+        // `commitments` is a `HashMap`; sort so the reported set is comparable across parties.
+        let mut contributing_parties = self.commitments.keys().copied().collect::<Vec<_>>();
+        contributing_parties.sort_unstable();
+
         Ok(Finished {
+            contributing_parties,
             my_idx: self.my_idx,
             session_id: self.session_id,
             sk_share: my_secret_key_share,

--- a/threshold-eddsa-babyjubjub/src/keygen/round2.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/round2.rs
@@ -3,7 +3,10 @@
 //! In this round every party sends the evaluation of its polynomial to the respective party over a
 //! private channel, which the receiving party verifies against the commitments from the first round.
 
-use crate::keygen::{MaliciousPartyError, Parameters, finished::Finished};
+use crate::{
+    keygen::{MaliciousPartyError, Parameters, finished::Finished},
+    shamir::utils,
+};
 use ark_ec::CurveGroup;
 use eyre::Result;
 use serde::{Deserialize, Serialize};
@@ -28,40 +31,12 @@ pub struct RoundTwo<C: CurveGroup> {
 /// This communication is intended to be sent *privately* to a specific other party.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoundTwoCommunication<C: CurveGroup> {
-    session_id: Uuid,
+    pub(crate) session_id: Uuid,
     #[serde(with = "ark_serde_compat::field")]
-    secret_share: C::ScalarField,
+    pub(crate) secret_share: C::ScalarField,
 }
 
 impl<C: CurveGroup> RoundTwo<C> {
-    fn evaluate_polynomial_in_exponent(coefficients: &[C::Affine], party_idx: u16) -> C {
-        debug_assert!(party_idx > 0, "party index must be non-zero");
-        // since the party index is non-zero, this is non zero
-        let x = C::ScalarField::from(u64::from(party_idx));
-
-        let mut result = C::zero();
-
-        // evaluate the poly using Horner's algorithm
-        for (idx, coeff) in coefficients.iter().rev().enumerate() {
-            // skip first mult
-            if idx != 0 {
-                result *= &x;
-            }
-            result += coeff;
-        }
-
-        result
-    }
-
-    fn verify_polynomial_evaluation(
-        commitments: &[C::Affine],
-        party_idx: u16,
-        share: &C::ScalarField,
-    ) -> bool {
-        let result = Self::evaluate_polynomial_in_exponent(commitments, party_idx);
-        result == C::generator() * share
-    }
-
     /// Retrieve the communication for the second round to be sent *privately* to the party with index `for_party`.
     ///
     /// This has to be called for each other party participating in the protocol to retrieve the message intended for this party.
@@ -70,6 +45,9 @@ impl<C: CurveGroup> RoundTwo<C> {
     /// # Errors
     /// Returns an error if `for_party` is not a valid party index for the used [`Parameters`].
     pub fn get_party_communication(&self, for_party: u16) -> Result<RoundTwoCommunication<C>> {
+        if for_party == 0 {
+            eyre::bail!("party index must be non-zero",);
+        }
         let idx = usize::from(for_party) - 1;
         let secret_share = *self.secret_shares.get(idx).ok_or(eyre::eyre!(
             "party index {for_party} invalid for used parameters"
@@ -109,14 +87,14 @@ impl<C: CurveGroup> RoundTwo<C> {
         }
 
         if self.received_party_messages.contains_key(&from) {
-            eyre::bail!("already added message for party {from}",);
+            eyre::bail!("already added message for party {from}");
         }
 
         if self.session_id != comm.session_id {
             eyre::bail!(MaliciousPartyError::new(from as usize));
         }
 
-        if !Self::verify_polynomial_evaluation(
+        if !utils::verify_polynomial_evaluation::<C>(
             &self.commitments[&from],
             self.my_idx,
             &comm.secret_share,
@@ -169,7 +147,7 @@ impl<C: CurveGroup> RoundTwo<C> {
                 continue;
             }
             let pk_share = self.commitments.values().fold(C::zero(), |acc, x| {
-                acc + Self::evaluate_polynomial_in_exponent(x, party_idx)
+                acc + utils::evaluate_polynomial_in_exponent::<C>(x, party_idx)
             });
             public_key_shares.insert(party_idx, pk_share.into_affine());
         }
@@ -180,6 +158,7 @@ impl<C: CurveGroup> RoundTwo<C> {
             .fold(C::zero(), |acc, x| acc + x[0]);
 
         Ok(Finished {
+            my_idx: self.my_idx,
             session_id: self.session_id,
             sk_share: my_secret_key_share,
             pk_shares: public_key_shares,

--- a/threshold-eddsa-babyjubjub/src/keygen/round2.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/round2.rs
@@ -4,7 +4,7 @@
 //! private channel, which the receiving party verifies against the commitments from the first round.
 
 use crate::{
-    keygen::{MaliciousPartyError, Parameters, finished::Finished},
+    keygen::{MaliciousPartyError, Parameters, SecretScalars, finished::Finished},
     shamir::utils,
 };
 use ark_ec::CurveGroup;
@@ -21,7 +21,7 @@ use uuid::Uuid;
 pub struct RoundTwo<C: CurveGroup> {
     pub(crate) session_id: Uuid,
     pub(crate) commitments: HashMap<u16, Vec<C::Affine>>,
-    pub(crate) secret_shares: Vec<C::ScalarField>,
+    pub(crate) secret_shares: SecretScalars<C::ScalarField>,
     pub(crate) my_idx: u16,
     pub(crate) params: Parameters,
     pub(crate) received_party_messages: HashMap<u16, C::ScalarField>,

--- a/threshold-eddsa-babyjubjub/src/keygen/round2.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/round2.rs
@@ -1,0 +1,189 @@
+//! The second round of the DKG protocol.
+//!
+//! In this round every party sends the evaluation of its polynomial to the respective party over a
+//! private channel, which the receiving party verifies against the commitments from the first round.
+
+use crate::keygen::{MaliciousPartyError, Parameters, finished::Finished};
+use ark_ec::CurveGroup;
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// The state of the DKG protocol in the second round.
+///
+/// In this round each party sends the evaluation of its polynomial to the respective party over a
+/// private channel, and checks the shares it receives against the commitments broadcast in the
+/// first round.
+pub struct RoundTwo<C: CurveGroup> {
+    pub(crate) session_id: Uuid,
+    pub(crate) commitments: HashMap<u16, Vec<C::Affine>>,
+    pub(crate) secret_shares: Vec<C::ScalarField>,
+    pub(crate) my_idx: u16,
+    pub(crate) params: Parameters,
+    pub(crate) received_party_messages: HashMap<u16, C::ScalarField>,
+}
+
+/// Communication in the second round of the DKG protocol.
+/// This communication is intended to be sent *privately* to a specific other party.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoundTwoCommunication<C: CurveGroup> {
+    session_id: Uuid,
+    #[serde(with = "ark_serde_compat::field")]
+    secret_share: C::ScalarField,
+}
+
+impl<C: CurveGroup> RoundTwo<C> {
+    fn evaluate_polynomial_in_exponent(coefficients: &[C::Affine], party_idx: u16) -> C {
+        debug_assert!(party_idx > 0, "party index must be non-zero");
+        // since the party index is non-zero, this is non zero
+        let x = C::ScalarField::from(u64::from(party_idx));
+
+        let mut result = C::zero();
+
+        // evaluate the poly using Horner's algorithm
+        for (idx, coeff) in coefficients.iter().rev().enumerate() {
+            // skip first mult
+            if idx != 0 {
+                result *= &x;
+            }
+            result += coeff;
+        }
+
+        result
+    }
+
+    fn verify_polynomial_evaluation(
+        commitments: &[C::Affine],
+        party_idx: u16,
+        share: &C::ScalarField,
+    ) -> bool {
+        let result = Self::evaluate_polynomial_in_exponent(commitments, party_idx);
+        result == C::generator() * share
+    }
+
+    /// Retrieve the communication for the second round to be sent *privately* to the party with index `for_party`.
+    ///
+    /// This has to be called for each other party participating in the protocol to retrieve the message intended for this party.
+    /// The message has to be sent using a private communication channel, and should not be available to other parties.
+    ///
+    /// # Errors
+    /// Returns an error if `for_party` is not a valid party index for the used [`Parameters`].
+    pub fn get_party_communication(&self, for_party: u16) -> Result<RoundTwoCommunication<C>> {
+        let idx = usize::from(for_party) - 1;
+        let secret_share = *self.secret_shares.get(idx).ok_or(eyre::eyre!(
+            "party index {for_party} invalid for used parameters"
+        ))?;
+
+        Ok(RoundTwoCommunication {
+            session_id: self.session_id,
+            secret_share,
+        })
+    }
+
+    /// Add a [`RoundTwoCommunication`] received from a party, verifying that everything is in order.
+    ///
+    /// # Errors
+    /// Returns a [`MaliciousPartyError`] identifying the offending party if its message carries a
+    /// different session id, or a secret share that does not verify against the commitments this
+    /// party broadcast in the first round.
+    /// All other errors indicate an invalid `from` index and are usually the fault of the local
+    /// party.
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "Keeps consistency with the first round, where the message is consumed"
+    )]
+    pub fn add_party_communication(
+        &mut self,
+        from: u16,
+        comm: RoundTwoCommunication<C>,
+    ) -> Result<()> {
+        if from == 0 {
+            eyre::bail!("party index must be non-zero",);
+        }
+        if from > self.params.number_of_parties {
+            eyre::bail!("party index {from} invalid for parameters",);
+        }
+        if from == self.my_idx {
+            eyre::bail!("do not add messages from own party {from}",);
+        }
+
+        if self.received_party_messages.contains_key(&from) {
+            eyre::bail!("already added message for party {from}",);
+        }
+
+        if self.session_id != comm.session_id {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+
+        if !Self::verify_polynomial_evaluation(
+            &self.commitments[&from],
+            self.my_idx,
+            &comm.secret_share,
+        ) {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+        self.received_party_messages.insert(from, comm.secret_share);
+        Ok(())
+    }
+
+    /// Returns a list of party indices for which we have not yet received and added a [`RoundTwoCommunication`] message.
+    #[must_use]
+    pub fn get_missing_parties(&self) -> Vec<u16> {
+        (1..=self.params.number_of_parties)
+            .filter(|idx| *idx != self.my_idx)
+            .filter(|idx| !self.received_party_messages.contains_key(idx))
+            .collect()
+    }
+
+    /// Indicates if the protocol is ready to advance into the next state.
+    /// See [`RoundTwo::get_missing_parties`] for parties we are still missing information from.
+    #[must_use]
+    pub fn can_advance(&self) -> bool {
+        self.received_party_messages.len() == usize::from(self.params.number_of_parties) - 1
+    }
+
+    /// Try to finalize the DKG protocol, putting it in a state where the results of the protocol can be obtained.
+    ///
+    /// # Errors
+    /// Returns an error if not all [`RoundTwoCommunication`] messages have been added yet, i.e., if
+    /// [`RoundTwo::can_advance`] returns false.
+    pub fn finalize(self) -> Result<Finished<C>> {
+        if !self.can_advance() {
+            eyre::bail!("cannot finalize, not all messages received");
+        }
+
+        let my_secret_key_share = self
+            .received_party_messages
+            .values()
+            .fold(self.secret_shares[self.my_idx as usize - 1], |acc, x| {
+                acc + x
+            });
+        let my_public_key_share = (C::generator() * my_secret_key_share).into_affine();
+
+        let mut public_key_shares = HashMap::new();
+        public_key_shares.insert(self.my_idx, my_public_key_share);
+
+        for party_idx in 1..=self.params.number_of_parties {
+            if party_idx == self.my_idx {
+                continue;
+            }
+            let pk_share = self.commitments.values().fold(C::zero(), |acc, x| {
+                acc + Self::evaluate_polynomial_in_exponent(x, party_idx)
+            });
+            public_key_shares.insert(party_idx, pk_share.into_affine());
+        }
+
+        let public_key = self
+            .commitments
+            .values()
+            .fold(C::zero(), |acc, x| acc + x[0]);
+
+        Ok(Finished {
+            session_id: self.session_id,
+            sk_share: my_secret_key_share,
+            pk_shares: public_key_shares,
+            pk: public_key.into_affine(),
+        })
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/keygen/round2.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/round2.rs
@@ -5,11 +5,13 @@
 
 use crate::{
     keygen::{
-        MaliciousPartyError, Parameters, SecretScalars, blame::BlameRound, finished::Finished,
+        MaliciousPartyError, Parameters, SecretScalarMap, SecretScalars, blame::BlameRound,
+        finished::Finished,
     },
     shamir::utils,
 };
 use ark_ec::CurveGroup;
+use ark_ff::Zero;
 use eyre::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
@@ -26,17 +28,25 @@ pub struct RoundTwo<C: CurveGroup> {
     pub(crate) secret_shares: SecretScalars<C::ScalarField>,
     pub(crate) my_idx: u16,
     pub(crate) params: Parameters,
-    pub(crate) received_party_messages: HashMap<u16, C::ScalarField>,
+    pub(crate) received_party_messages: SecretScalarMap<C::ScalarField>,
     pub(crate) failed_parties: BTreeSet<u16>,
+    pub(crate) disqualified_parties: BTreeSet<u16>,
 }
 
 /// Communication in the second round of the DKG protocol.
 /// This communication is intended to be sent *privately* to a specific other party.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct RoundTwoCommunication<C: CurveGroup> {
     pub(crate) session_id: Uuid,
     #[serde(with = "ark_serde_compat::field")]
     pub(crate) secret_share: C::ScalarField,
+}
+
+impl<C: CurveGroup> Drop for RoundTwoCommunication<C> {
+    fn drop(&mut self) {
+        use zeroize::Zeroize as _;
+        self.secret_share.zeroize();
+    }
 }
 
 impl<C: CurveGroup> RoundTwo<C> {
@@ -70,14 +80,10 @@ impl<C: CurveGroup> RoundTwo<C> {
     /// party broadcast in the first round.
     /// All other errors indicate an invalid `from` index and are usually the fault of the local
     /// party.
-    #[expect(
-        clippy::needless_pass_by_value,
-        reason = "Keeps consistency with the first round, where the message is consumed"
-    )]
     pub fn add_party_communication(
         &mut self,
         from: u16,
-        comm: RoundTwoCommunication<C>,
+        comm: &RoundTwoCommunication<C>,
     ) -> Result<()> {
         if from == 0 {
             eyre::bail!("party index must be non-zero",);
@@ -87,6 +93,9 @@ impl<C: CurveGroup> RoundTwo<C> {
         }
         if from == self.my_idx {
             eyre::bail!("do not add messages from own party {from}",);
+        }
+        if !self.commitments.contains_key(&from) {
+            eyre::bail!("party {from} is not a qualified dealer");
         }
 
         if self.received_party_messages.contains_key(&from) {
@@ -130,6 +139,9 @@ impl<C: CurveGroup> RoundTwo<C> {
         if from == self.my_idx {
             eyre::bail!("do not add messages from own party {from}");
         }
+        if !self.commitments.contains_key(&from) {
+            eyre::bail!("party {from} is not a qualified dealer");
+        }
 
         if self.received_party_messages.contains_key(&from) {
             eyre::bail!("already added message for party {from}");
@@ -153,17 +165,40 @@ impl<C: CurveGroup> RoundTwo<C> {
     /// Returns a list of party indices for which we have not yet received and added a [`RoundTwoCommunication`] message.
     #[must_use]
     pub fn get_missing_parties(&self) -> Vec<u16> {
-        (1..=self.params.number_of_parties)
-            .filter(|idx| *idx != self.my_idx)
+        self.commitments
+            .keys()
+            .filter(|idx| **idx != self.my_idx)
             .filter(|idx| !self.received_party_messages.contains_key(idx))
+            .copied()
             .collect()
+    }
+
+    /// Turn an externally confirmed missing private share into a public complaint.
+    ///
+    /// The placeholder is never used as output: [`RoundTwo::finalize`] rejects unresolved
+    /// complaints and the blame round either replaces it with a valid revelation or disqualifies
+    /// the dealer.
+    ///
+    /// # Errors
+    /// Returns an error for an invalid dealer or if that dealer's share was already received.
+    pub fn complain_missing_party(&mut self, from: u16) -> Result<()> {
+        if from == self.my_idx || !self.commitments.contains_key(&from) {
+            eyre::bail!("invalid dealer for a missing-share complaint");
+        }
+        if self.received_party_messages.contains_key(&from) {
+            eyre::bail!("dealer {from}'s private share was already received");
+        }
+        self.failed_parties.insert(from);
+        self.received_party_messages
+            .insert(from, C::ScalarField::zero());
+        Ok(())
     }
 
     /// Indicates if the protocol is ready to advance into the next state.
     /// See [`RoundTwo::get_missing_parties`] for parties we are still missing information from.
     #[must_use]
     pub fn can_advance(&self) -> bool {
-        self.received_party_messages.len() == usize::from(self.params.number_of_parties) - 1
+        self.received_party_messages.len() == self.commitments.len() - 1
     }
 
     /// Try to finalize the DKG protocol, putting it in a state where the results of the protocol can be obtained.
@@ -174,6 +209,9 @@ impl<C: CurveGroup> RoundTwo<C> {
     pub fn finalize(self) -> Result<Finished<C>> {
         if !self.can_advance() {
             eyre::bail!("cannot finalize, not all messages received");
+        }
+        if !self.failed_parties.is_empty() {
+            eyre::bail!("cannot finalize with unresolved complaints; enter the blame round");
         }
 
         let my_secret_key_share = self
@@ -187,7 +225,9 @@ impl<C: CurveGroup> RoundTwo<C> {
         let mut public_key_shares = HashMap::new();
         public_key_shares.insert(self.my_idx, my_public_key_share);
 
-        for party_idx in 1..=self.params.number_of_parties {
+        for party_idx in (1..=self.params.number_of_parties)
+            .filter(|party| !self.disqualified_parties.contains(party))
+        {
             if party_idx == self.my_idx {
                 continue;
             }

--- a/threshold-eddsa-babyjubjub/src/keygen/round2.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/round2.rs
@@ -4,13 +4,15 @@
 //! private channel, which the receiving party verifies against the commitments from the first round.
 
 use crate::{
-    keygen::{MaliciousPartyError, Parameters, SecretScalars, finished::Finished},
+    keygen::{
+        MaliciousPartyError, Parameters, SecretScalars, blame::BlameRound, finished::Finished,
+    },
     shamir::utils,
 };
 use ark_ec::CurveGroup;
 use eyre::Result;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use uuid::Uuid;
 
 /// The state of the DKG protocol in the second round.
@@ -25,6 +27,7 @@ pub struct RoundTwo<C: CurveGroup> {
     pub(crate) my_idx: u16,
     pub(crate) params: Parameters,
     pub(crate) received_party_messages: HashMap<u16, C::ScalarField>,
+    pub(crate) failed_parties: BTreeSet<u16>,
 }
 
 /// Communication in the second round of the DKG protocol.
@@ -91,7 +94,7 @@ impl<C: CurveGroup> RoundTwo<C> {
         }
 
         if self.session_id != comm.session_id {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
+            eyre::bail!("session id mismatch for party {from}");
         }
 
         if !utils::verify_polynomial_evaluation::<C>(
@@ -100,6 +103,48 @@ impl<C: CurveGroup> RoundTwo<C> {
             &comm.secret_share,
         ) {
             eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+        self.received_party_messages.insert(from, comm.secret_share);
+        Ok(())
+    }
+
+    /// Add a private share while retaining malformed shares for the optional public blame round.
+    ///
+    /// Unlike [`RoundTwo::add_party_communication`], a share that fails its polynomial equation is
+    /// recorded as a complaint rather than returning [`MaliciousPartyError`]. Structural errors,
+    /// duplicate messages, and session mismatches still return an error.
+    ///
+    /// # Errors
+    /// Returns an error for an invalid sender, duplicate communication, or mismatched session.
+    pub fn add_party_communication_for_blame(
+        &mut self,
+        from: u16,
+        comm: &RoundTwoCommunication<C>,
+    ) -> Result<()> {
+        if from == 0 {
+            eyre::bail!("party index must be non-zero",);
+        }
+        if from > self.params.number_of_parties {
+            eyre::bail!("party index {from} invalid for parameters",);
+        }
+        if from == self.my_idx {
+            eyre::bail!("do not add messages from own party {from}");
+        }
+
+        if self.received_party_messages.contains_key(&from) {
+            eyre::bail!("already added message for party {from}");
+        }
+
+        if self.session_id != comm.session_id {
+            eyre::bail!("session id mismatch for party {from}");
+        }
+
+        if !utils::verify_polynomial_evaluation::<C>(
+            &self.commitments[&from],
+            self.my_idx,
+            &comm.secret_share,
+        ) {
+            self.failed_parties.insert(from);
         }
         self.received_party_messages.insert(from, comm.secret_share);
         Ok(())
@@ -164,5 +209,13 @@ impl<C: CurveGroup> RoundTwo<C> {
             pk_shares: public_key_shares,
             pk: public_key.into_affine(),
         })
+    }
+
+    /// Enter the optional public blame round after collecting every private share.
+    ///
+    /// # Errors
+    /// Returns an error unless all round-two communications have been collected.
+    pub fn blame_round(self) -> Result<BlameRound<C>> {
+        BlameRound::new(self)
     }
 }

--- a/threshold-eddsa-babyjubjub/src/keygen/schnorr.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/schnorr.rs
@@ -4,11 +4,13 @@
 //! the constant term of their polynomial. This prevents a party from choosing its contribution to
 //! the public key depending on the contributions of the other parties.
 
+use crate::keygen::Parameters;
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{PrimeField, UniformRand};
 use ark_serialize::{CanonicalSerialize, CompressedChecked, Valid};
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// A non-interactive Schnorr proof of knowledge of the discrete logarithm of a curve point.
@@ -19,9 +21,23 @@ pub struct SchnorrZkProof<C: CurveGroup> {
 }
 
 impl<C: CurveGroup> SchnorrZkProof<C> {
-    fn challenge_hash(party_idx: u16, public: &C::Affine, big_r: &C::Affine) -> C::ScalarField {
+    const CONTEXT_DOMAIN: &'static [u8] = b"PEDPOP_SCHNORR_POP_V1";
+
+    fn challenge_hash(
+        context: &[u8],
+        party_idx: u16,
+        public: &C::Affine,
+        big_r: &C::Affine,
+        transcript_commitments: &[C::Affine],
+    ) -> C::ScalarField {
         let mut random_oracle = blake3::Hasher::new();
-        random_oracle.update("nizk_context".as_bytes());
+        random_oracle.update(Self::CONTEXT_DOMAIN);
+        random_oracle.update(
+            &u64::try_from(context.len())
+                .expect("context length fits into u64")
+                .to_be_bytes(),
+        );
+        random_oracle.update(context);
         random_oracle.update(&party_idx.to_be_bytes());
 
         let mut buf = Vec::with_capacity(public.compressed_size());
@@ -37,6 +53,9 @@ impl<C: CurveGroup> SchnorrZkProof<C> {
         // first one is the message, second one the public key, to keep compatibility with standard Schnorr signatures according to CKM21 (https://eprint.iacr.org/2021/1375)
         serialize_point(public);
         serialize_point(big_r);
+        for comm in transcript_commitments {
+            serialize_point(comm);
+        }
 
         let mut hash_output = random_oracle.finalize_xof();
 
@@ -52,16 +71,18 @@ impl<C: CurveGroup> SchnorrZkProof<C> {
     /// The index of the proving party is bound into the challenge hash, so that a proof cannot be
     /// replayed by another party.
     pub fn new<R: Rng + CryptoRng>(
+        context: &[u8],
         party_idx: u16,
         secret: &C::ScalarField,
         public: &C::Affine,
+        transcript_commitments: &[C::Affine],
         rng: &mut R,
     ) -> SchnorrZkProof<C> {
         let r = C::ScalarField::rand(rng);
         let big_r = C::generator() * r;
         let big_r = big_r.into_affine();
 
-        let c = Self::challenge_hash(party_idx, public, &big_r);
+        let c = Self::challenge_hash(context, party_idx, public, &big_r, transcript_commitments);
 
         let z = r + c * secret;
 
@@ -72,17 +93,43 @@ impl<C: CurveGroup> SchnorrZkProof<C> {
     }
 
     /// Verify the proof against the `public` point claimed by the party with index `party_idx`.
-    pub fn verify(&self, party_idx: u16, public: &C::Affine) -> bool {
+    pub fn verify(
+        &self,
+        context: &[u8],
+        party_idx: u16,
+        public: &C::Affine,
+        transcript_commitments: &[C::Affine],
+    ) -> bool {
         if public.is_zero() || public.check().is_err() || self.big_r.check().is_err() {
             return false;
         }
 
-        let c = Self::challenge_hash(party_idx, public, &self.big_r);
+        let c = Self::challenge_hash(
+            context,
+            party_idx,
+            public,
+            &self.big_r,
+            transcript_commitments,
+        );
 
         let v = (C::generator() * self.z) - self.big_r.0 - (*public * c);
         let v = v.into_affine().clear_cofactor();
         v.is_zero()
     }
+}
+
+pub(crate) fn proof_context(domain: &[u8], session_id: Uuid, parameters: &[Parameters]) -> Vec<u8> {
+    let session_id_bytes = session_id.as_bytes();
+    let len = domain.len() + session_id_bytes.len() + parameters.len() * 4;
+    let mut context = Vec::with_capacity(len);
+    context.extend_from_slice(domain);
+    context.extend_from_slice(session_id.as_bytes());
+    for parameters in parameters {
+        context.extend_from_slice(&parameters.number_of_parties.to_be_bytes());
+        context.extend_from_slice(&parameters.threshold.to_be_bytes());
+    }
+    assert_eq!(context.len(), len, "context length matches expected length");
+    context
 }
 
 #[cfg(test)]
@@ -98,8 +145,9 @@ mod tests {
         let idx = 1;
         let secret = ScalarField::rand(&mut rng);
         let public = (Affine::generator() * secret).into_affine();
-        let nizk = SchnorrZkProof::<Curve>::new(idx, &secret, &public, &mut rng);
-        assert!(nizk.verify(idx, &public));
+        let nizk = SchnorrZkProof::<Curve>::new(b"test", idx, &secret, &public, &[], &mut rng);
+        assert!(nizk.verify(b"test", idx, &public, &[]));
+        assert!(!nizk.verify(b"other session", idx, &public, &[]));
     }
 
     #[test]
@@ -108,7 +156,7 @@ mod tests {
         let idx = 1;
         let secret = ScalarField::rand(&mut rng);
         let public = (Affine::generator() * secret + Curve::generator()).into_affine();
-        let nizk = SchnorrZkProof::<Curve>::new(idx, &secret, &public, &mut rng);
-        assert!(!nizk.verify(idx, &public));
+        let nizk = SchnorrZkProof::<Curve>::new(b"test", idx, &secret, &public, &[], &mut rng);
+        assert!(!nizk.verify(b"test", idx, &public, &[]));
     }
 }

--- a/threshold-eddsa-babyjubjub/src/keygen/schnorr.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/schnorr.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound(serialize = "", deserialize = ""))]
 /// A non-interactive Schnorr proof of knowledge of the discrete logarithm of a curve point.
 pub struct SchnorrZkProof<C: CurveGroup> {
     big_r: CompressedChecked<C::Affine>,

--- a/threshold-eddsa-babyjubjub/src/keygen/schnorr.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/schnorr.rs
@@ -1,0 +1,114 @@
+//! Non-interactive proof of knowledge of a discrete logarithm.
+//!
+//! The parties use this Schnorr proof in the first round of the DKG protocol to show that they know
+//! the constant term of their polynomial. This prevents a party from choosing its contribution to
+//! the public key depending on the contributions of the other parties.
+
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::{PrimeField, UniformRand};
+use ark_serialize::{CanonicalSerialize, CompressedChecked, Valid};
+use rand::{CryptoRng, Rng};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// A non-interactive Schnorr proof of knowledge of the discrete logarithm of a curve point.
+pub struct SchnorrZkProof<C: CurveGroup> {
+    big_r: CompressedChecked<C::Affine>,
+    #[serde(with = "ark_serde_compat::field")]
+    z: C::ScalarField,
+}
+
+impl<C: CurveGroup> SchnorrZkProof<C> {
+    fn challenge_hash(party_idx: u16, public: &C::Affine, big_r: &C::Affine) -> C::ScalarField {
+        let mut random_oracle = blake3::Hasher::new();
+        random_oracle.update("nizk_context".as_bytes());
+        random_oracle.update(&party_idx.to_be_bytes());
+
+        let mut buf = Vec::with_capacity(public.compressed_size());
+        // serialize an Affine point in canonical compressed form
+        let mut serialize_point = |point: &C::Affine| {
+            point
+                .serialize_compressed(&mut buf)
+                .expect("can serialize point into a vec");
+            random_oracle.update(&buf);
+            buf.clear();
+        };
+
+        // first one is the message, second one the public key, to keep compatibility with standard Schnorr signatures according to CKM21 (https://eprint.iacr.org/2021/1375)
+        serialize_point(public);
+        serialize_point(big_r);
+
+        let mut hash_output = random_oracle.finalize_xof();
+
+        // We use 64 bytes to have enough statistical security against modulo bias
+        let mut unreduced_b = [0u8; 64];
+        hash_output.fill(&mut unreduced_b);
+
+        C::ScalarField::from_le_bytes_mod_order(&unreduced_b)
+    }
+
+    /// Create a proof of knowledge of `secret`, the discrete logarithm of `public`.
+    ///
+    /// The index of the proving party is bound into the challenge hash, so that a proof cannot be
+    /// replayed by another party.
+    pub fn new<R: Rng + CryptoRng>(
+        party_idx: u16,
+        secret: &C::ScalarField,
+        public: &C::Affine,
+        rng: &mut R,
+    ) -> SchnorrZkProof<C> {
+        let r = C::ScalarField::rand(rng);
+        let big_r = C::generator() * r;
+        let big_r = big_r.into_affine();
+
+        let c = Self::challenge_hash(party_idx, public, &big_r);
+
+        let z = r + c * secret;
+
+        SchnorrZkProof {
+            big_r: CompressedChecked(big_r),
+            z,
+        }
+    }
+
+    /// Verify the proof against the `public` point claimed by the party with index `party_idx`.
+    pub fn verify(&self, party_idx: u16, public: &C::Affine) -> bool {
+        if public.is_zero() || public.check().is_err() || self.big_r.check().is_err() {
+            return false;
+        }
+
+        let c = Self::challenge_hash(party_idx, public, &self.big_r);
+
+        let v = (C::generator() * self.z) - self.big_r.0 - (*public * c);
+        let v = v.into_affine().clear_cofactor();
+        v.is_zero()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Affine, Curve, ScalarField};
+    use ark_ec::PrimeGroup;
+    use rand::thread_rng;
+
+    #[test]
+    fn basic_schnorr_nizk() {
+        let mut rng = thread_rng();
+        let idx = 1;
+        let secret = ScalarField::rand(&mut rng);
+        let public = (Affine::generator() * secret).into_affine();
+        let nizk = SchnorrZkProof::<Curve>::new(idx, &secret, &public, &mut rng);
+        assert!(nizk.verify(idx, &public));
+    }
+
+    #[test]
+    fn basic_schnorr_nizk_invalid() {
+        let mut rng = thread_rng();
+        let idx = 1;
+        let secret = ScalarField::rand(&mut rng);
+        let public = (Affine::generator() * secret + Curve::generator()).into_affine();
+        let nizk = SchnorrZkProof::<Curve>::new(idx, &secret, &public, &mut rng);
+        assert!(!nizk.verify(idx, &public));
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/keygen/test.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/test.rs
@@ -183,7 +183,13 @@ fn test_keygen_and_sign(num_parties: u16, threshold: u16, cheating_positions: &[
         .iter()
         .enumerate()
         .map(|(position, party)| {
-            DLogShareShamir::new(party.sk_share, party_id(position), num_parties, threshold)
+            DLogShareShamir::new(
+                party.sk_share,
+                &public_key,
+                party_id(position),
+                num_parties,
+                threshold,
+            )
                 .expect("valid DKG signing share metadata")
         })
         .collect::<Vec<_>>();
@@ -509,11 +515,11 @@ fn run_optional_blame_round(mode: BlameTestMode, num_parties: u16, threshold: u1
             .shares[0]
             .share += crate::ScalarField::one();
     }
-    for (receiver, state) in blame_rounds.iter_mut().take(completing_parties).enumerate() {
+    // Reliable broadcast means the accused dealer sees its own revelation exactly as the others do,
+    // so it judges itself with the same rule and reaches the same verdict.
+    for state in blame_rounds.iter_mut().take(completing_parties) {
         for (dealer, revelation) in revelations.iter().enumerate() {
-            if receiver != dealer
-                && let Some(revelation) = revelation
-            {
+            if let Some(revelation) = revelation {
                 state
                     .add_revelation(party_id(dealer), revelation)
                     .expect("accused dealer's public revelation is processed");
@@ -543,32 +549,34 @@ fn run_optional_blame_round(mode: BlameTestMode, num_parties: u16, threshold: u1
     } else {
         vec![1]
     };
-    if mode == BlameTestMode::Missing {
-        for disqualified in &expected_disqualified {
-            let Err(_) = &results[usize::from(*disqualified) - 1] else {
-                panic!("a disqualified participant must not finalize");
-            };
-        }
-    }
-    let honest_results = results
+    // A blame-round disqualification drops the dealer's polynomial contribution, not its standing as
+    // a shareholder: it completed round two, so it can compute its share of the surviving aggregate
+    // polynomial either way. Every party that reached the blame round therefore finalizes, and all of
+    // them — the disqualified dealer included — agree on the public key and on every public-key
+    // share. Only round-one disqualifications remove a party from the sharing.
+    let all_results = results
         .iter()
-        .enumerate()
-        .filter(|(position, _)| !expected_disqualified.contains(&party_id(*position)))
-        .filter_map(|(_, result)| result.as_ref().ok())
+        .filter_map(|result| result.as_ref().ok())
         .collect::<Vec<_>>();
-    let expected = &honest_results[0].finished;
-    for result in honest_results {
+    assert_eq!(
+        all_results.len(),
+        completing_parties,
+        "every party that reached the blame round finalizes"
+    );
+    let expected = &all_results[0].finished;
+    for result in all_results {
         assert_eq!(result.disqualified_parties, expected_disqualified);
         assert!(result.excluded_verdict_parties.is_empty());
+        assert_eq!(
+            result.finished.pk_shares.len(),
+            usize::from(num_parties),
+            "a blame-round disqualification drops the polynomial, not the shareholder"
+        );
         assert!(
             expected_disqualified
                 .iter()
-                .all(|party| !result.finished.pk_shares.contains_key(party)),
-            "disqualified parties must not have public-key shares"
-        );
-        assert_eq!(
-            result.finished.pk_shares.len(),
-            usize::from(num_parties) - expected_disqualified.len()
+                .all(|party| result.finished.pk_shares.contains_key(party)),
+            "a disqualified dealer keeps a public-key share"
         );
         assert_eq!(result.finished.pk, expected.pk);
         assert_eq!(result.finished.pk_shares, expected.pk_shares);
@@ -577,6 +585,22 @@ fn run_optional_blame_round(mode: BlameTestMode, num_parties: u16, threshold: u1
             result.finished.pk_shares[&result.finished.my_idx]
         );
     }
+
+    // Any `threshold` of the resulting shares still reconstruct the same key, so the sharing is
+    // usable across the full shareholder set rather than only the qualified dealers.
+    let sk_shares = results
+        .iter()
+        .filter_map(|result| result.as_ref().ok())
+        .map(|result| result.finished.sk_share)
+        .collect::<Vec<_>>();
+    let degree = usize::from(threshold) - 1;
+    assert_eq!(
+        (Affine::generator()
+            * test_utils::reconstruct_random_shares(&sk_shares, degree, &mut rng))
+        .into_affine(),
+        expected.pk,
+        "any threshold of the surviving shares reconstructs the key"
+    );
 }
 
 #[test]

--- a/threshold-eddsa-babyjubjub/src/keygen/test.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/test.rs
@@ -1,0 +1,225 @@
+//! End-to-end tests for the distributed key generation protocol, covering the DKG on its own as
+//! well as creating a signature with the resulting key shares.
+
+use crate::{
+    Affine, BaseField, Curve,
+    keygen::{Parameters, finished::Finished, round1::RoundOne},
+    shamir::{secret::DLogShareShamir, test::test_threshold_eddsa_inner, utils::test_utils},
+};
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::UniformRand;
+use eddsa_babyjubjub::EdDSAPublicKey;
+use rand::{CryptoRng, Rng};
+use uuid::Uuid;
+
+/// Runs the full DKG protocol for `num_parties` honest parties, where `threshold` parties are
+/// required to reconstruct the key, and returns the final state of every party.
+fn run_keygen<R: Rng + CryptoRng>(
+    num_parties: u16,
+    threshold: u16,
+    session_id: Uuid,
+    rng: &mut R,
+) -> Vec<Finished<Curve>> {
+    // 1) Every party samples a polynomial and broadcasts the commitments to its coefficients
+    let mut round1 = (1..=num_parties)
+        .map(|party_id| {
+            RoundOne::<Curve>::new(
+                Parameters::new(num_parties, threshold),
+                party_id,
+                session_id,
+                rng,
+            )
+            .expect("party index is valid for the parameters")
+        })
+        .collect::<Vec<_>>();
+
+    let broadcasts = round1
+        .iter()
+        .map(RoundOne::get_broadcast_message)
+        .collect::<Vec<_>>();
+
+    for (my_pos, party) in round1.iter_mut().enumerate() {
+        for (from_pos, broadcast) in broadcasts.iter().enumerate() {
+            if from_pos == my_pos {
+                continue;
+            }
+            party
+                .add_party_communication(party_id(from_pos), broadcast.clone())
+                .expect("broadcast of an honest party is accepted");
+        }
+        assert!(
+            party.get_missing_parties().is_empty(),
+            "all round one broadcasts have been added"
+        );
+        assert!(party.can_advance(), "round one is complete");
+    }
+
+    // 2) Every party sends the evaluation of its polynomial to the respective party
+    let mut round2 = round1
+        .into_iter()
+        .map(|party| party.round2().expect("round one is complete"))
+        .collect::<Vec<_>>();
+
+    let communications = round2
+        .iter()
+        .map(|party| {
+            (1..=num_parties)
+                .map(|for_party| {
+                    party
+                        .get_party_communication(for_party)
+                        .expect("party index is valid for the parameters")
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    for (my_pos, party) in round2.iter_mut().enumerate() {
+        for (from_pos, comms) in communications.iter().enumerate() {
+            if from_pos == my_pos {
+                continue;
+            }
+            party
+                .add_party_communication(party_id(from_pos), comms[my_pos].clone())
+                .expect("secret share of an honest party verifies against its commitments");
+        }
+        assert!(
+            party.get_missing_parties().is_empty(),
+            "all round two messages have been added"
+        );
+        assert!(party.can_advance(), "round two is complete");
+    }
+
+    round2
+        .into_iter()
+        .map(|party| party.finalize().expect("round two is complete"))
+        .collect()
+}
+
+/// Translates a position in the vector of parties into the party index used by the protocol, which
+/// starts at one.
+fn party_id(position: usize) -> u16 {
+    u16::try_from(position + 1).expect("Fits into u16")
+}
+
+fn test_keygen(num_parties: u16, threshold: u16) {
+    let mut rng = rand::thread_rng();
+    let degree = usize::from(threshold) - 1;
+
+    let session_id = Uuid::new_v4();
+    let parties = run_keygen(num_parties, threshold, session_id, &mut rng);
+    assert_eq!(
+        parties.len(),
+        usize::from(num_parties),
+        "every party finished the protocol"
+    );
+
+    // All parties agree on the session, the public key and the public key shares
+    let public_key = parties[0].pk;
+    for party in &parties {
+        assert_eq!(party.session_id, session_id, "session id is preserved");
+        assert_eq!(party.pk, public_key, "parties agree on the public key");
+        assert_eq!(
+            party.pk_shares.len(),
+            usize::from(num_parties),
+            "there is a public key share for every party"
+        );
+        for other_id in 1..=num_parties {
+            assert_eq!(
+                party.pk_shares[&other_id], parties[0].pk_shares[&other_id],
+                "parties agree on the public key share of party {other_id}"
+            );
+        }
+    }
+
+    // The public key share of a party is the public counterpart of its secret key share
+    for (position, party) in parties.iter().enumerate() {
+        let my_id = party_id(position);
+        assert_eq!(
+            party.pk_shares[&my_id],
+            (Affine::generator() * party.sk_share).into_affine(),
+            "public key share of party {my_id} matches its secret key share"
+        );
+    }
+
+    // The secret key shares are a Shamir sharing of the discrete logarithm of the public key, so
+    // any `threshold` of them reconstruct a secret matching the public key
+    let sk_shares = parties
+        .iter()
+        .map(|party| party.sk_share)
+        .collect::<Vec<_>>();
+    let secret_key = test_utils::reconstruct_random_shares(&sk_shares, degree, &mut rng);
+    assert_eq!(
+        (Affine::generator() * secret_key).into_affine(),
+        public_key,
+        "reconstructed secret key matches the public key"
+    );
+
+    // The same holds for the public key shares in the exponent
+    let pk_shares = parties
+        .iter()
+        .enumerate()
+        .map(|(position, party)| party.pk_shares[&party_id(position)].into_group())
+        .collect::<Vec<_>>();
+    let public_key_ =
+        test_utils::reconstruct_random_pointshares(&pk_shares, degree, &mut rng).into_affine();
+    assert_eq!(
+        public_key_, public_key,
+        "reconstructed public key shares match the public key"
+    );
+}
+
+fn test_keygen_and_sign(num_parties: u16, threshold: u16, cheating_positions: &[usize]) {
+    let mut rng = rand::thread_rng();
+    let degree = usize::from(threshold) - 1;
+
+    // Create the signing key shares via the DKG protocol
+    let parties = run_keygen(num_parties, threshold, Uuid::new_v4(), &mut rng);
+    let public_key = EdDSAPublicKey { pk: parties[0].pk };
+
+    let message = BaseField::rand(&mut rng);
+
+    let x_shares = parties
+        .iter()
+        .map(|party| DLogShareShamir(party.sk_share))
+        .collect::<Vec<_>>();
+
+    let public_key_shares = (1..=num_parties)
+        .map(|party_id| parties[0].pk_shares[&party_id])
+        .collect::<Vec<_>>();
+
+    test_threshold_eddsa_inner(
+        usize::from(num_parties),
+        degree,
+        cheating_positions,
+        message,
+        &x_shares,
+        &public_key,
+        &public_key_shares,
+        &mut rng,
+    );
+}
+
+#[test]
+fn test_keygen_3_2() {
+    test_keygen(3, 2);
+}
+
+#[test]
+fn test_keygen_7_4() {
+    test_keygen(7, 4);
+}
+
+#[test]
+fn test_keygen_and_sign_3_2() {
+    test_keygen_and_sign(3, 2, &[]);
+}
+
+#[test]
+fn test_keygen_and_sign_7_4() {
+    test_keygen_and_sign(7, 4, &[]);
+}
+
+#[test]
+fn test_keygen_and_sign_identifies_cheating_parties() {
+    test_keygen_and_sign(7, 4, &[0, 2]);
+}

--- a/threshold-eddsa-babyjubjub/src/keygen/test.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/test.rs
@@ -7,7 +7,7 @@ use crate::{
     shamir::{secret::DLogShareShamir, test::test_threshold_eddsa_inner, utils::test_utils},
 };
 use ark_ec::{AffineRepr, CurveGroup};
-use ark_ff::UniformRand;
+use ark_ff::{One, UniformRand};
 use eddsa_babyjubjub::EdDSAPublicKey;
 use rand::{CryptoRng, Rng};
 use uuid::Uuid;
@@ -222,4 +222,199 @@ fn test_keygen_and_sign_7_4() {
 #[test]
 fn test_keygen_and_sign_identifies_cheating_parties() {
     test_keygen_and_sign(7, 4, &[0, 2]);
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BlameTestMode {
+    Valid,
+    Malformed,
+    Missing,
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "Exercises the complete optional two-broadcast workflow"
+)]
+fn run_optional_blame_round(mode: BlameTestMode, num_parties: u16, threshold: u16) {
+    let mut rng = rand::thread_rng();
+    assert!(
+        num_parties >= 3,
+        "blame test fixture requires at least three parties"
+    );
+    let parameters = Parameters::new(num_parties, threshold);
+    let session_id = Uuid::new_v4();
+    let mut round1 = (1..=num_parties)
+        .map(|party| {
+            RoundOne::<Curve>::new(parameters, party, session_id, &mut rng)
+                .expect("valid DKG parameters")
+        })
+        .collect::<Vec<_>>();
+    let round1_broadcasts = round1
+        .iter()
+        .map(RoundOne::get_broadcast_message)
+        .collect::<Vec<_>>();
+    for (receiver, state) in round1.iter_mut().enumerate() {
+        for (dealer, broadcast) in round1_broadcasts.iter().enumerate() {
+            if receiver != dealer {
+                state
+                    .add_party_communication(party_id(dealer), broadcast.clone())
+                    .expect("honest round-one broadcast");
+            }
+        }
+    }
+
+    let mut round2 = round1
+        .into_iter()
+        .map(|state| state.round2().expect("round one complete"))
+        .collect::<Vec<_>>();
+    let mut private_shares = round2
+        .iter()
+        .map(|dealer| {
+            (1..=num_parties)
+                .map(|receiver| {
+                    dealer
+                        .get_party_communication(receiver)
+                        .expect("valid receiver")
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    // Dealer 1 equivocates only toward receiver 2, which will complain publicly.
+    private_shares[0][1].secret_share += crate::ScalarField::one();
+    for (receiver, state) in round2.iter_mut().enumerate() {
+        for (dealer, shares) in private_shares.iter().enumerate() {
+            if receiver != dealer {
+                state
+                    .add_party_communication_for_blame(party_id(dealer), &shares[receiver])
+                    .expect("well-formed private communication is retained for blame");
+            }
+        }
+    }
+
+    let mut blame_rounds = round2
+        .into_iter()
+        .map(|state| state.blame_round().expect("all private shares received"))
+        .collect::<Vec<_>>();
+    let verdicts = blame_rounds
+        .iter()
+        .map(crate::keygen::blame::BlameRound::verdict)
+        .collect::<Vec<_>>();
+    assert!(verdicts[0].is_ok());
+    assert_eq!(
+        verdicts[1]
+            .blamed_parties()
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![1]
+    );
+    assert!(verdicts[2].is_ok());
+    for (receiver, state) in blame_rounds.iter_mut().enumerate() {
+        for (sender, verdict) in verdicts.iter().enumerate() {
+            if receiver != sender {
+                state
+                    .add_verdict(party_id(sender), verdict.clone())
+                    .expect("valid verdict broadcast");
+            }
+        }
+    }
+
+    let mut revelations = blame_rounds
+        .iter_mut()
+        .enumerate()
+        .map(|(dealer, state)| {
+            if mode == BlameTestMode::Missing && dealer == 0 {
+                None
+            } else {
+                state.revelation().expect("verdict exchange complete")
+            }
+        })
+        .collect::<Vec<_>>();
+    if mode == BlameTestMode::Malformed {
+        revelations[0]
+            .as_mut()
+            .expect("dealer 1 was accused")
+            .shares[0]
+            .share += crate::ScalarField::one();
+    }
+    for (receiver, state) in blame_rounds.iter_mut().enumerate() {
+        for (dealer, revelation) in revelations.iter().enumerate() {
+            if receiver != dealer
+                && let Some(revelation) = revelation
+            {
+                state
+                    .add_revelation(party_id(dealer), revelation)
+                    .expect("accused dealer's public revelation is processed");
+            }
+        }
+    }
+    if mode == BlameTestMode::Missing {
+        for state in &mut blame_rounds {
+            state
+                .disqualify_missing_dealer(1)
+                .expect("accused dealer can be disqualified after withholding its share");
+        }
+    }
+
+    let results = blame_rounds
+        .into_iter()
+        .map(crate::keygen::blame::BlameRound::finalize)
+        .collect::<Vec<_>>();
+    let expected_disqualified = if mode == BlameTestMode::Valid {
+        vec![]
+    } else {
+        vec![1]
+    };
+    if mode == BlameTestMode::Missing {
+        for disqualified in &expected_disqualified {
+            assert!(results[usize::from(*disqualified) - 1].is_err());
+        }
+    }
+    let honest_results = results
+        .iter()
+        .enumerate()
+        .filter(|(position, _)| !expected_disqualified.contains(&party_id(*position)))
+        .filter_map(|(_, result)| result.as_ref().ok())
+        .collect::<Vec<_>>();
+    let expected = &honest_results[0].finished;
+    for result in honest_results {
+        assert_eq!(result.disqualified_parties, expected_disqualified);
+        assert_eq!(
+            result
+                .disqualified_public_key_shares()
+                .keys()
+                .copied()
+                .collect::<Vec<_>>(),
+            expected_disqualified
+        );
+        assert!(
+            result
+                .disqualified_public_key_shares()
+                .values()
+                .all(AffineRepr::is_zero),
+            "disqualified parties must have default public-key shares"
+        );
+        assert_eq!(result.finished.pk, expected.pk);
+        assert_eq!(result.finished.pk_shares, expected.pk_shares);
+        assert_eq!(
+            (Affine::generator() * result.finished.sk_share).into_affine(),
+            result.finished.pk_shares[&result.finished.my_idx]
+        );
+    }
+}
+
+#[test]
+fn optional_blame_round_accepts_valid_dealer_revelation() {
+    run_optional_blame_round(BlameTestMode::Valid, 3, 2);
+}
+
+#[test]
+fn optional_blame_round_disqualifies_malformed_dealer_revelation() {
+    run_optional_blame_round(BlameTestMode::Malformed, 3, 2);
+}
+
+#[test]
+fn optional_blame_round_disqualifies_missing_dealer_revelation() {
+    run_optional_blame_round(BlameTestMode::Missing, 3, 2);
 }

--- a/threshold-eddsa-babyjubjub/src/keygen/test.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/test.rs
@@ -3,7 +3,11 @@
 
 use crate::{
     Affine, BaseField, Curve,
-    keygen::{Parameters, finished::Finished, round1::RoundOne},
+    keygen::{
+        Parameters,
+        finished::Finished,
+        round1::{RoundOne, RoundOneBroadcast},
+    },
     shamir::{secret::DLogShareShamir, test::test_threshold_eddsa_inner, utils::test_utils},
 };
 use ark_ec::{AffineRepr, CurveGroup};
@@ -190,7 +194,7 @@ fn test_keygen_and_sign(num_parties: u16, threshold: u16, cheating_positions: &[
                 num_parties,
                 threshold,
             )
-                .expect("valid DKG signing share metadata")
+            .expect("valid DKG signing share metadata")
         })
         .collect::<Vec<_>>();
 
@@ -248,6 +252,24 @@ fn parameters_reject_invalid_deserialization() {
 }
 
 #[test]
+fn round_one_broadcast_serde_round_trips() {
+    let mut rng = rand::thread_rng();
+    let params = Parameters::new(3, 2);
+    let session_id = Uuid::new_v4();
+    let dealer = RoundOne::<Curve>::new(params, 1, session_id, &mut rng).expect("valid DKG party");
+    let mut receiver =
+        RoundOne::<Curve>::new(params, 2, session_id, &mut rng).expect("valid DKG party");
+    let encoded = serde_json::to_vec(&dealer.get_broadcast_message())
+        .expect("round-one broadcast serializes");
+    let decoded = serde_json::from_slice::<RoundOneBroadcast<Curve>>(&encoded)
+        .expect("round-one broadcast deserializes");
+
+    receiver
+        .add_party_communication(1, decoded)
+        .expect("round-tripped broadcast verifies");
+}
+
+#[test]
 fn dkg_can_disqualify_a_missing_round_one_dealer() {
     let mut rng = rand::thread_rng();
     let params = Parameters::new(3, 2);
@@ -281,6 +303,9 @@ fn dkg_can_disqualify_a_missing_round_one_dealer() {
                 .expect("round one complete after disqualification")
         })
         .collect::<Vec<_>>();
+    let Err(_) = round2[0].get_party_communication(3) else {
+        panic!("a disqualified round-one party must not receive a private share");
+    };
     let to_one = round2[1]
         .get_party_communication(1)
         .expect("share for party one");
@@ -595,9 +620,8 @@ fn run_optional_blame_round(mode: BlameTestMode, num_parties: u16, threshold: u1
         .collect::<Vec<_>>();
     let degree = usize::from(threshold) - 1;
     assert_eq!(
-        (Affine::generator()
-            * test_utils::reconstruct_random_shares(&sk_shares, degree, &mut rng))
-        .into_affine(),
+        (Affine::generator() * test_utils::reconstruct_random_shares(&sk_shares, degree, &mut rng))
+            .into_affine(),
         expected.pk,
         "any threshold of the surviving shares reconstructs the key"
     );
@@ -626,4 +650,42 @@ fn optional_blame_round_recovers_a_missing_private_message() {
 #[test]
 fn optional_blame_round_disqualifies_a_missing_verdict_dealer() {
     run_optional_blame_round(BlameTestMode::MissingVerdict, 3, 2);
+}
+
+/// Blame attribution must survive being logged, and a local configuration mismatch must not be
+/// reported as remote misbehaviour.
+#[test]
+fn round_one_errors_separate_attributable_blame_from_a_local_mismatch() {
+    let mut rng = rand::thread_rng();
+    let session_id = Uuid::new_v4();
+    let params = Parameters::new(3, 2);
+    let mut state =
+        RoundOne::<Curve>::new(params, 1, session_id, &mut rng).expect("valid DKG party");
+
+    // A proof of possession binds the prover's index, so replaying party 2's broadcast as party 3
+    // fails cryptographically and is attributable.
+    let broadcast = RoundOne::<Curve>::new(params, 2, session_id, &mut rng)
+        .expect("valid DKG party")
+        .get_broadcast_message();
+    let error = state
+        .add_party_communication(3, broadcast)
+        .expect_err("a replayed proof must not verify");
+    assert_eq!(error.attributable_parties(), vec![3]);
+    assert!(
+        error.to_string().contains('3'),
+        "the party ID must survive being logged: {error}"
+    );
+
+    // A peer configured with a different threshold looks wrong locally, but is not at fault.
+    let mismatched = RoundOne::<Curve>::new(Parameters::new(3, 3), 2, session_id, &mut rng)
+        .expect("valid DKG party")
+        .get_broadcast_message();
+    let error = state
+        .add_party_communication(2, mismatched)
+        .expect_err("a commitment count mismatch must be rejected");
+    assert!(
+        error.attributable_parties().is_empty(),
+        "a configuration mismatch must not accuse anyone: {error}"
+    );
+    assert!(matches!(error, crate::keygen::MessageError::Malformed(_)));
 }

--- a/threshold-eddsa-babyjubjub/src/keygen/test.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/test.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 /// Runs the full DKG protocol for `num_parties` honest parties, where `threshold` parties are
 /// required to reconstruct the key, and returns the final state of every party.
-fn run_keygen<R: Rng + CryptoRng>(
+pub(crate) fn run_keygen<R: Rng + CryptoRng>(
     num_parties: u16,
     threshold: u16,
     session_id: Uuid,

--- a/threshold-eddsa-babyjubjub/src/keygen/test.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/test.rs
@@ -380,20 +380,15 @@ fn run_optional_blame_round(mode: BlameTestMode, num_parties: u16, threshold: u1
     let expected = &honest_results[0].finished;
     for result in honest_results {
         assert_eq!(result.disqualified_parties, expected_disqualified);
-        assert_eq!(
-            result
-                .disqualified_public_key_shares()
-                .keys()
-                .copied()
-                .collect::<Vec<_>>(),
-            expected_disqualified
-        );
         assert!(
-            result
-                .disqualified_public_key_shares()
-                .values()
-                .all(AffineRepr::is_zero),
-            "disqualified parties must have default public-key shares"
+            expected_disqualified
+                .iter()
+                .all(|party| !result.finished.pk_shares.contains_key(party)),
+            "disqualified parties must not have public-key shares"
+        );
+        assert_eq!(
+            result.finished.pk_shares.len(),
+            usize::from(num_parties) - expected_disqualified.len()
         );
         assert_eq!(result.finished.pk, expected.pk);
         assert_eq!(result.finished.pk_shares, expected.pk_shares);

--- a/threshold-eddsa-babyjubjub/src/keygen/test.rs
+++ b/threshold-eddsa-babyjubjub/src/keygen/test.rs
@@ -10,6 +10,7 @@ use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{One, UniformRand};
 use eddsa_babyjubjub::EdDSAPublicKey;
 use rand::{CryptoRng, Rng};
+use std::collections::BTreeSet;
 use uuid::Uuid;
 
 /// Runs the full DKG protocol for `num_parties` honest parties, where `threshold` parties are
@@ -79,7 +80,7 @@ pub(crate) fn run_keygen<R: Rng + CryptoRng>(
                 continue;
             }
             party
-                .add_party_communication(party_id(from_pos), comms[my_pos].clone())
+                .add_party_communication(party_id(from_pos), &comms[my_pos])
                 .expect("secret share of an honest party verifies against its commitments");
         }
         assert!(
@@ -180,7 +181,11 @@ fn test_keygen_and_sign(num_parties: u16, threshold: u16, cheating_positions: &[
 
     let x_shares = parties
         .iter()
-        .map(|party| DLogShareShamir(party.sk_share))
+        .enumerate()
+        .map(|(position, party)| {
+            DLogShareShamir::new(party.sk_share, party_id(position), num_parties, threshold)
+                .expect("valid DKG signing share metadata")
+        })
         .collect::<Vec<_>>();
 
     let public_key_shares = (1..=num_parties)
@@ -224,11 +229,155 @@ fn test_keygen_and_sign_identifies_cheating_parties() {
     test_keygen_and_sign(7, 4, &[0, 2]);
 }
 
+#[test]
+fn parameters_reject_invalid_deserialization() {
+    let Err(_) = serde_json::from_str::<Parameters>(r#"{"number_of_parties":3,"threshold":0}"#)
+    else {
+        panic!("zero threshold must be rejected");
+    };
+    let Err(_) = serde_json::from_str::<Parameters>(r#"{"number_of_parties":2,"threshold":3}"#)
+    else {
+        panic!("threshold above the party count must be rejected");
+    };
+}
+
+#[test]
+fn dkg_can_disqualify_a_missing_round_one_dealer() {
+    let mut rng = rand::thread_rng();
+    let params = Parameters::new(3, 2);
+    let session_id = Uuid::new_v4();
+    let mut states = (1..=2)
+        .map(|party| {
+            RoundOne::<Curve>::new(params, party, session_id, &mut rng).expect("valid DKG party")
+        })
+        .collect::<Vec<_>>();
+    let broadcasts = states
+        .iter()
+        .map(RoundOne::get_broadcast_message)
+        .collect::<Vec<_>>();
+    states[0]
+        .add_party_communication(2, broadcasts[1].clone())
+        .expect("surviving dealer broadcast");
+    states[1]
+        .add_party_communication(1, broadcasts[0].clone())
+        .expect("surviving dealer broadcast");
+    for state in &mut states {
+        state
+            .disqualify_party(3)
+            .expect("common timeout disqualifies missing dealer");
+    }
+
+    let mut round2 = states
+        .into_iter()
+        .map(|state| {
+            state
+                .round2()
+                .expect("round one complete after disqualification")
+        })
+        .collect::<Vec<_>>();
+    let to_one = round2[1]
+        .get_party_communication(1)
+        .expect("share for party one");
+    let to_two = round2[0]
+        .get_party_communication(2)
+        .expect("share for party two");
+    let Err(_) = round2[0].add_party_communication(3, &to_one) else {
+        panic!("communication attributed to a disqualified dealer must be rejected");
+    };
+    round2[0]
+        .add_party_communication(2, &to_one)
+        .expect("qualified dealer share");
+    round2[1]
+        .add_party_communication(1, &to_two)
+        .expect("qualified dealer share");
+    let results = round2
+        .into_iter()
+        .map(|state| state.finalize().expect("qualified DKG finalizes"))
+        .collect::<Vec<_>>();
+    assert_eq!(results[0].pk, results[1].pk);
+    assert_eq!(results[0].pk_shares, results[1].pk_shares);
+    assert!(!results[0].pk_shares.contains_key(&3));
+}
+
+#[test]
+fn dkg_can_retroactively_apply_an_agreed_disqualification_set() {
+    let mut rng = rand::thread_rng();
+    let params = Parameters::new(3, 2);
+    let session_id = Uuid::new_v4();
+    let mut states = (1..=3)
+        .map(|party| {
+            RoundOne::<Curve>::new(params, party, session_id, &mut rng).expect("valid DKG party")
+        })
+        .collect::<Vec<_>>();
+    let broadcasts = states
+        .iter()
+        .map(RoundOne::get_broadcast_message)
+        .collect::<Vec<_>>();
+    for (receiver, state) in states.iter_mut().enumerate() {
+        for (dealer, broadcast) in broadcasts.iter().enumerate() {
+            if receiver != dealer {
+                state
+                    .add_party_communication(party_id(dealer), broadcast.clone())
+                    .expect("initial broadcast is accepted");
+            }
+        }
+    }
+
+    let agreed_disqualifications = BTreeSet::from([3]);
+    for state in &mut states {
+        state
+            .disqualify_parties(&agreed_disqualifications)
+            .expect("agreed set is applied atomically");
+    }
+    let excluded = states.pop().expect("state for excluded party");
+    assert!(!excluded.can_advance());
+    let Err(_) = excluded.round2() else {
+        panic!("a locally disqualified dealer must terminate");
+    };
+
+    let mut round2 = states
+        .into_iter()
+        .map(|state| state.round2().expect("qualified party advances"))
+        .collect::<Vec<_>>();
+    let to_one = round2[1]
+        .get_party_communication(1)
+        .expect("share for party one");
+    let to_two = round2[0]
+        .get_party_communication(2)
+        .expect("share for party two");
+    round2[0]
+        .add_party_communication(2, &to_one)
+        .expect("qualified dealer share");
+    round2[1]
+        .add_party_communication(1, &to_two)
+        .expect("qualified dealer share");
+    let results = round2
+        .into_iter()
+        .map(|state| state.finalize().expect("qualified DKG finalizes"))
+        .collect::<Vec<_>>();
+    assert_eq!(results[0].pk, results[1].pk);
+    assert_eq!(results[0].pk_shares, results[1].pk_shares);
+    assert!(!results[0].pk_shares.contains_key(&3));
+}
+
+#[test]
+fn dkg_disqualification_preserves_the_threshold() {
+    let mut rng = rand::thread_rng();
+    let mut state = RoundOne::<Curve>::new(Parameters::new(3, 3), 1, Uuid::new_v4(), &mut rng)
+        .expect("valid DKG party");
+    let Err(_) = state.disqualify_parties(&BTreeSet::from([3])) else {
+        panic!("disqualification below the threshold must be rejected");
+    };
+    assert_eq!(state.get_missing_parties(), vec![2, 3]);
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum BlameTestMode {
     Valid,
     Malformed,
     Missing,
+    MissingPrivateMessage,
+    MissingVerdict,
 }
 
 #[allow(
@@ -281,13 +430,21 @@ fn run_optional_blame_round(mode: BlameTestMode, num_parties: u16, threshold: u1
         .collect::<Vec<_>>();
 
     // Dealer 1 equivocates only toward receiver 2, which will complain publicly.
-    private_shares[0][1].secret_share += crate::ScalarField::one();
+    if mode != BlameTestMode::MissingPrivateMessage {
+        private_shares[0][1].secret_share += crate::ScalarField::one();
+    }
     for (receiver, state) in round2.iter_mut().enumerate() {
         for (dealer, shares) in private_shares.iter().enumerate() {
             if receiver != dealer {
-                state
-                    .add_party_communication_for_blame(party_id(dealer), &shares[receiver])
-                    .expect("well-formed private communication is retained for blame");
+                if mode == BlameTestMode::MissingPrivateMessage && receiver == 1 && dealer == 0 {
+                    state
+                        .complain_missing_party(1)
+                        .expect("missing private share becomes a complaint");
+                } else {
+                    state
+                        .add_party_communication_for_blame(party_id(dealer), &shares[receiver])
+                        .expect("well-formed private communication is retained for blame");
+                }
             }
         }
     }
@@ -310,18 +467,32 @@ fn run_optional_blame_round(mode: BlameTestMode, num_parties: u16, threshold: u1
         vec![1]
     );
     assert!(verdicts[2].is_ok());
-    for (receiver, state) in blame_rounds.iter_mut().enumerate() {
+    let completing_parties = if mode == BlameTestMode::MissingVerdict {
+        blame_rounds.len() - 1
+    } else {
+        blame_rounds.len()
+    };
+    for (receiver, state) in blame_rounds.iter_mut().take(completing_parties).enumerate() {
         for (sender, verdict) in verdicts.iter().enumerate() {
-            if receiver != sender {
+            if receiver != sender
+                && !(mode == BlameTestMode::MissingVerdict
+                    && sender + 1 == usize::from(num_parties))
+            {
                 state
                     .add_verdict(party_id(sender), verdict.clone())
                     .expect("valid verdict broadcast");
             }
         }
+        if mode == BlameTestMode::MissingVerdict {
+            state
+                .disqualify_missing_verdict(num_parties)
+                .expect("common timeout disqualifies a dealer that withheld its verdict");
+        }
     }
 
     let mut revelations = blame_rounds
         .iter_mut()
+        .take(completing_parties)
         .enumerate()
         .map(|(dealer, state)| {
             if mode == BlameTestMode::Missing && dealer == 0 {
@@ -338,7 +509,7 @@ fn run_optional_blame_round(mode: BlameTestMode, num_parties: u16, threshold: u1
             .shares[0]
             .share += crate::ScalarField::one();
     }
-    for (receiver, state) in blame_rounds.iter_mut().enumerate() {
+    for (receiver, state) in blame_rounds.iter_mut().take(completing_parties).enumerate() {
         for (dealer, revelation) in revelations.iter().enumerate() {
             if receiver != dealer
                 && let Some(revelation) = revelation
@@ -359,16 +530,24 @@ fn run_optional_blame_round(mode: BlameTestMode, num_parties: u16, threshold: u1
 
     let results = blame_rounds
         .into_iter()
+        .take(completing_parties)
         .map(crate::keygen::blame::BlameRound::finalize)
         .collect::<Vec<_>>();
-    let expected_disqualified = if mode == BlameTestMode::Valid {
+    let expected_disqualified = if mode == BlameTestMode::MissingVerdict {
+        vec![num_parties]
+    } else if matches!(
+        mode,
+        BlameTestMode::Valid | BlameTestMode::MissingPrivateMessage
+    ) {
         vec![]
     } else {
         vec![1]
     };
     if mode == BlameTestMode::Missing {
         for disqualified in &expected_disqualified {
-            assert!(results[usize::from(*disqualified) - 1].is_err());
+            let Err(_) = &results[usize::from(*disqualified) - 1] else {
+                panic!("a disqualified participant must not finalize");
+            };
         }
     }
     let honest_results = results
@@ -380,6 +559,7 @@ fn run_optional_blame_round(mode: BlameTestMode, num_parties: u16, threshold: u1
     let expected = &honest_results[0].finished;
     for result in honest_results {
         assert_eq!(result.disqualified_parties, expected_disqualified);
+        assert!(result.excluded_verdict_parties.is_empty());
         assert!(
             expected_disqualified
                 .iter()
@@ -412,4 +592,14 @@ fn optional_blame_round_disqualifies_malformed_dealer_revelation() {
 #[test]
 fn optional_blame_round_disqualifies_missing_dealer_revelation() {
     run_optional_blame_round(BlameTestMode::Missing, 3, 2);
+}
+
+#[test]
+fn optional_blame_round_recovers_a_missing_private_message() {
+    run_optional_blame_round(BlameTestMode::MissingPrivateMessage, 3, 2);
+}
+
+#[test]
+fn optional_blame_round_disqualifies_a_missing_verdict_dealer() {
+    run_optional_blame_round(BlameTestMode::MissingVerdict, 3, 2);
 }

--- a/threshold-eddsa-babyjubjub/src/lib.rs
+++ b/threshold-eddsa-babyjubjub/src/lib.rs
@@ -1,0 +1,35 @@
+//! Threshold `EdDSA` signatures over the Baby Jubjub curve based on Frost3, using Poseidon2 as the internal hash function for the Fiat-Shamir transform.
+
+#[cfg(feature = "additive")]
+pub mod additive;
+pub mod commit;
+pub mod nonce;
+pub mod partial_commit;
+pub mod session;
+pub mod shamir;
+pub mod signature;
+
+use ark_ec::{CurveGroup, PrimeGroup};
+
+pub(crate) type Curve = ark_babyjubjub::EdwardsProjective;
+pub(crate) type Affine = <Curve as CurveGroup>::Affine;
+pub(crate) type BaseField = <Curve as CurveGroup>::BaseField;
+pub(crate) type Projective = ark_babyjubjub::EdwardsProjective;
+pub(crate) type ScalarField = <Curve as PrimeGroup>::ScalarField;
+
+pub(crate) const FROST_3_NONCE_COMBINER_LABEL: &[u8] = b"FROST_3_NONCE_COMBINER";
+
+/// The error returned by the aggregation with identifiable abort.
+///
+/// Carries the IDs of the parties that contributed a malformed signature share.
+#[derive(Debug, thiserror::Error)]
+#[error("Cheating parties detected")]
+pub struct CheatingPartiesError(Vec<usize>);
+
+impl CheatingPartiesError {
+    /// Consumes the error and returns the IDs of the parties identified as cheating.
+    #[must_use]
+    pub fn into_inner(self) -> Vec<usize> {
+        self.0
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/lib.rs
+++ b/threshold-eddsa-babyjubjub/src/lib.rs
@@ -21,11 +21,9 @@ pub(crate) type ScalarField = <Curve as PrimeGroup>::ScalarField;
 
 pub(crate) const FROST_3_NONCE_COMBINER_LABEL: &[u8] = b"FROST_3_NONCE_COMBINER";
 
-/// The error returned by the aggregation with identifiable abort.
-///
-/// Carries the IDs of the parties that contributed a malformed signature share.
+/// The IDs of the parties that contributed a malformed signature share.
 #[derive(Debug, thiserror::Error)]
-#[error("Malicious parties detected")]
+#[error("Malicious parties detected: {0:?}")]
 pub struct MaliciousPartiesError(Vec<usize>);
 
 impl MaliciousPartiesError {
@@ -33,5 +31,52 @@ impl MaliciousPartiesError {
     #[must_use]
     pub fn into_inner(self) -> Vec<usize> {
         self.0
+    }
+
+    /// The IDs of the parties identified as cheating.
+    #[must_use]
+    pub fn party_ids(&self) -> &[usize] {
+        &self.0
+    }
+}
+
+/// The error returned by aggregation with identifiable abort.
+///
+/// The two variants are the two distinguishable outcomes, and the distinction matters: only
+/// [`IdentifiableAbortError::MaliciousParties`] attributes blame. An
+/// [`IdentifiableAbortError::InvalidInput`] means the aggregator's own inputs were inconsistent, so
+/// no share was validated and no participant may be accused. Use
+/// [`IdentifiableAbortError::malicious_parties`] rather than only logging the error, or the
+/// attribution this API exists to produce is silently discarded.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum IdentifiableAbortError {
+    /// At least one signature share failed its validation equation.
+    #[error(transparent)]
+    MaliciousParties(#[from] MaliciousPartiesError),
+    /// The supplied aggregation inputs do not form a consistent set, so no share could be checked.
+    #[error(transparent)]
+    InvalidInput(#[from] eyre::Report),
+}
+
+impl IdentifiableAbortError {
+    /// The IDs of the parties whose signature share failed validation, or `None` when the abort was
+    /// caused by inconsistent aggregation input rather than by a malformed share.
+    #[must_use]
+    pub fn malicious_parties(&self) -> Option<&[usize]> {
+        match self {
+            Self::MaliciousParties(error) => Some(error.party_ids()),
+            Self::InvalidInput(_) => None,
+        }
+    }
+
+    /// Consumes the error and returns the IDs of the parties identified as cheating, or `None` when
+    /// the abort was caused by inconsistent aggregation input.
+    #[must_use]
+    pub fn into_malicious_parties(self) -> Option<Vec<usize>> {
+        match self {
+            Self::MaliciousParties(error) => Some(error.into_inner()),
+            Self::InvalidInput(_) => None,
+        }
     }
 }

--- a/threshold-eddsa-babyjubjub/src/lib.rs
+++ b/threshold-eddsa-babyjubjub/src/lib.rs
@@ -7,6 +7,7 @@ pub mod keygen;
 pub mod nonce;
 pub mod partial_commit;
 pub mod reshare;
+mod serde_utils;
 pub mod session;
 pub mod shamir;
 pub mod signature;

--- a/threshold-eddsa-babyjubjub/src/lib.rs
+++ b/threshold-eddsa-babyjubjub/src/lib.rs
@@ -3,6 +3,7 @@
 #[cfg(feature = "additive")]
 pub mod additive;
 pub mod commit;
+pub mod keygen;
 pub mod nonce;
 pub mod partial_commit;
 pub mod session;
@@ -23,10 +24,10 @@ pub(crate) const FROST_3_NONCE_COMBINER_LABEL: &[u8] = b"FROST_3_NONCE_COMBINER"
 ///
 /// Carries the IDs of the parties that contributed a malformed signature share.
 #[derive(Debug, thiserror::Error)]
-#[error("Cheating parties detected")]
-pub struct CheatingPartiesError(Vec<usize>);
+#[error("Malicious parties detected")]
+pub struct MaliciousPartiesError(Vec<usize>);
 
-impl CheatingPartiesError {
+impl MaliciousPartiesError {
     /// Consumes the error and returns the IDs of the parties identified as cheating.
     #[must_use]
     pub fn into_inner(self) -> Vec<usize> {

--- a/threshold-eddsa-babyjubjub/src/lib.rs
+++ b/threshold-eddsa-babyjubjub/src/lib.rs
@@ -6,6 +6,7 @@ pub mod commit;
 pub mod keygen;
 pub mod nonce;
 pub mod partial_commit;
+pub mod reshare;
 pub mod session;
 pub mod shamir;
 pub mod signature;

--- a/threshold-eddsa-babyjubjub/src/nonce.rs
+++ b/threshold-eddsa-babyjubjub/src/nonce.rs
@@ -1,0 +1,81 @@
+//! Two-Nonce Combination for Threshold `EdDSA`
+//!
+//! This module derives the full signing randomness `r = d + e*b` from the aggregated two-nonce
+//! commitments, where the binding factor `b` is a hash over the session ID, the contributing
+//! parties, the public key, both nonce commitments, and the message.
+//!
+//! The primitives defined here are agnostic to the underlying threshold sharing scheme and are used by both
+//! additive and Shamir variants, which are implemented in their respective submodules `additive` and `shamir`.
+//!
+//! Binding the randomness to all of these inputs is what makes concurrent signing sessions safe,
+//! as required by Frost3.
+
+use crate::{Affine, BaseField, ScalarField};
+use ark_ec::CurveGroup;
+use ark_ff::PrimeField;
+use ark_serialize::CanonicalSerialize;
+use eddsa_babyjubjub::EdDSAPublicKey;
+use uuid::Uuid;
+
+pub(crate) struct CombineTwoNonceRandomnessArgs<'a> {
+    pub(crate) session_id: Uuid,
+    pub(crate) message: BaseField,
+    pub(crate) public_key: EdDSAPublicKey,
+    pub(crate) d: Affine,
+    pub(crate) e: Affine,
+    pub(crate) parties: &'a [u16],
+}
+
+/// Combines the two-nonce randomness shares into the full randomness used in the challenge.
+/// Returns (r, b) where r = d + e*b
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "This method should consume the args"
+)]
+pub(crate) fn combine_two_nonce_randomness(
+    args: CombineTwoNonceRandomnessArgs<'_>,
+) -> (Affine, ScalarField) {
+    let CombineTwoNonceRandomnessArgs {
+        session_id,
+        message,
+        public_key,
+        d,
+        e,
+        parties,
+    } = args;
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(crate::FROST_3_NONCE_COMBINER_LABEL);
+    hasher.update(session_id.as_bytes());
+    for party in parties {
+        hasher.update(&party.to_le_bytes());
+    }
+    let mut buf = Vec::with_capacity(d.compressed_size());
+
+    // serialize an Affine point in canonical compressed form
+    let mut serialize_point = |point: &Affine| {
+        point
+            .serialize_compressed(&mut buf)
+            .expect("can serialize point into a vec");
+        hasher.update(&buf);
+        buf.clear();
+    };
+    serialize_point(&public_key.pk);
+    serialize_point(&d);
+    serialize_point(&e);
+
+    let mut buf = Vec::with_capacity(message.compressed_size());
+    message
+        .serialize_compressed(&mut buf)
+        .expect("can serialize field into a vec");
+    hasher.update(&buf);
+
+    let mut hash_output = hasher.finalize_xof();
+
+    // We use 64 bytes to have enough statistical security against modulo bias
+    let mut unreduced_b = [0u8; 64];
+    hash_output.fill(&mut unreduced_b);
+
+    let b = ScalarField::from_le_bytes_mod_order(&unreduced_b);
+    let r = d + e * b;
+    (r.into_affine(), b)
+}

--- a/threshold-eddsa-babyjubjub/src/nonce.rs
+++ b/threshold-eddsa-babyjubjub/src/nonce.rs
@@ -46,8 +46,15 @@ pub(crate) fn combine_two_nonce_randomness(
     let mut hasher = blake3::Hasher::new();
     hasher.update(crate::FROST_3_NONCE_COMBINER_LABEL);
     hasher.update(session_id.as_bytes());
+    // The signer set is the only variable-length field in the preimage, so it is length-prefixed:
+    // without the prefix, injectivity would rely on every following field staying fixed-width.
+    hasher.update(
+        &u64::try_from(parties.len())
+            .expect("signer set length fits into u64")
+            .to_be_bytes(),
+    );
     for party in parties {
-        hasher.update(&party.to_le_bytes());
+        hasher.update(&party.to_be_bytes());
     }
     let mut buf = Vec::with_capacity(d.compressed_size());
 

--- a/threshold-eddsa-babyjubjub/src/partial_commit.rs
+++ b/threshold-eddsa-babyjubjub/src/partial_commit.rs
@@ -1,0 +1,30 @@
+//! Distributed Partial Commitments for Threshold `EdDSA`
+//!
+//! This module defines the `PartialEdDSACommitments` struct.
+//! Each participating party generates commitment shares that
+//! are then aggregated to produce a non-interactive challenge hash for the `EdDSA` signature, without.
+//!
+//! The primitives defined here are agnostic to the underlying threshold sharing scheme and are used by both
+//! additive and Shamir variants, which are implemented in their respective submodules `additive` and `shamir`.
+//!
+//! This module provides:
+//! - Per-party commitment structures for partial commitment (nonce splits).
+//!
+//! Secret randomness is never clonable, and session types deliberately do not implement `Debug` to avoid accidental leakage.
+
+use crate::Affine;
+use ark_serde_compat::babyjubjub;
+use serde::{Deserialize, Serialize};
+
+/// Per-party commitments to the distributed `EdDSA` signature protocol.
+///
+/// Each party sends these commitments, which consist of a split of the actual response and nonce splits, for aggregation and creation of the global challenge hash.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartialEdDSACommitments {
+    #[serde(with = "babyjubjub::affine")]
+    /// The share of G*d, the first part of the two-nonce commitment to the randomness r = d + e*b
+    pub(crate) d: Affine,
+    #[serde(with = "babyjubjub::affine")]
+    /// The share of G*e, the second part of the two-nonce commitment to the randomness r = d + e*b
+    pub(crate) e: Affine,
+}

--- a/threshold-eddsa-babyjubjub/src/partial_commit.rs
+++ b/threshold-eddsa-babyjubjub/src/partial_commit.rs
@@ -21,10 +21,18 @@ use serde::{Deserialize, Serialize};
 /// Each party sends these commitments, which consist of a split of the actual response and nonce splits, for aggregation and creation of the global challenge hash.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PartialEdDSACommitments {
+    /// The claimed ID of the party that created this commitment.
+    pub(crate) party_id: u16,
     #[serde(with = "babyjubjub::affine")]
     /// The share of G*d, the first part of the two-nonce commitment to the randomness r = d + e*b
     pub(crate) d: Affine,
     #[serde(with = "babyjubjub::affine")]
     /// The share of G*e, the second part of the two-nonce commitment to the randomness r = d + e*b
     pub(crate) e: Affine,
+}
+
+impl PartialEdDSACommitments {
+    pub(crate) fn party_id(&self) -> u16 {
+        self.party_id
+    }
 }

--- a/threshold-eddsa-babyjubjub/src/reshare/blame.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/blame.rs
@@ -9,7 +9,10 @@ use crate::{
         blame::{BlameResult, BlameRevelation, BlameVerdict},
         finished::Finished,
     },
-    reshare::{receiver::ReShareProtocolReceiver, sender_set::ReShareSenderSet},
+    reshare::{
+        receiver::{ReShareProtocolReceiver, ReceivedShares},
+        sender_set::ReShareSenderSet,
+    },
     shamir::utils,
 };
 use ark_ec::CurveGroup;
@@ -21,10 +24,11 @@ use uuid::Uuid;
 /// Receiver-side state for the optional resharing blame round.
 pub struct ReShareBlameRound<C: CurveGroup> {
     my_idx: u16,
-    received_shares: HashMap<u16, (C::ScalarField, Vec<C::Affine>)>,
+    received_shares: ReceivedShares<C>,
     reshare_senders: ReShareSenderSet<C>,
     session_id: Uuid,
     verdicts: BTreeMap<u16, BlameVerdict>,
+    excluded_verdict_parties: BTreeSet<u16>,
     resolved_senders: BTreeSet<u16>,
     disqualified_senders: BTreeSet<u16>,
 }
@@ -47,8 +51,9 @@ impl<C: CurveGroup> ReShareBlameRound<C> {
             reshare_senders: receiver.reshare_senders,
             session_id: receiver.session_id,
             verdicts,
+            excluded_verdict_parties: BTreeSet::new(),
             resolved_senders: BTreeSet::new(),
-            disqualified_senders: BTreeSet::new(),
+            disqualified_senders: receiver.pre_disqualified_senders,
         })
     }
 
@@ -73,6 +78,9 @@ impl<C: CurveGroup> ReShareBlameRound<C> {
         if from == self.my_idx {
             eyre::bail!("do not add own verdict");
         }
+        if self.excluded_verdict_parties.contains(&from) {
+            eyre::bail!("new party {from}'s missing verdict was already excluded");
+        }
         if self.verdicts.contains_key(&from) {
             eyre::bail!("already added verdict from new party {from}");
         }
@@ -95,13 +103,47 @@ impl<C: CurveGroup> ReShareBlameRound<C> {
     pub fn missing_verdicts(&self) -> Vec<u16> {
         (1..=self.reshare_senders.new_parameters.number_of_parties)
             .filter(|party| !self.verdicts.contains_key(party))
+            .filter(|party| !self.excluded_verdict_parties.contains(party))
             .collect()
     }
 
     /// Whether every party's `Ok` or blame-set broadcast has been received.
     #[must_use]
     pub fn verdicts_complete(&self) -> bool {
-        self.verdicts.len() == usize::from(self.reshare_senders.new_parameters.number_of_parties)
+        self.missing_verdicts().is_empty()
+    }
+
+    /// Exclude a new party whose blame verdict was missing or rejected.
+    ///
+    /// This only removes the party from the blame-verdict barrier so the remaining receivers can
+    /// finish. It does not revoke a reshared secret-key share the party may already possess.
+    /// Every honest receiver that continues must apply the same externally agreed exclusion.
+    ///
+    /// # Errors
+    /// Returns an error for an invalid or local party, a party whose verdict was accepted, or a
+    /// party that was already excluded. It also returns an error if exclusion would leave fewer
+    /// than the new sharing's threshold receivers.
+    pub fn exclude_missing_verdict(&mut self, party: u16) -> Result<()> {
+        if party == 0 || party > self.reshare_senders.new_parameters.number_of_parties {
+            eyre::bail!("invalid new party for verdict exclusion: {party}");
+        }
+        if party == self.my_idx {
+            eyre::bail!("cannot exclude the local party's own verdict");
+        }
+        if self.verdicts.contains_key(&party) {
+            eyre::bail!("new party {party}'s verdict was already accepted");
+        }
+        if self.excluded_verdict_parties.contains(&party) {
+            eyre::bail!("new party {party}'s verdict was already excluded");
+        }
+        let remaining = usize::from(self.reshare_senders.new_parameters.number_of_parties)
+            - self.excluded_verdict_parties.len()
+            - 1;
+        if remaining < usize::from(self.reshare_senders.new_parameters.threshold) {
+            eyre::bail!("verdict exclusion would leave fewer than the threshold receivers");
+        }
+        self.excluded_verdict_parties.insert(party);
+        Ok(())
     }
 
     /// Map every accused old sender to the new parties accusing it.
@@ -162,6 +204,8 @@ impl<C: CurveGroup> ReShareBlameRound<C> {
                 .find(|share| share.receiver == self.my_idx)
                 && let Some(received) = self.received_shares.get_mut(&from)
             {
+                use zeroize::Zeroize as _;
+                received.0.zeroize();
                 received.0 = share.share;
             }
         } else {
@@ -210,6 +254,12 @@ impl<C: CurveGroup> ReShareBlameRound<C> {
         }
         if !self.missing_revelations()?.is_empty() {
             eyre::bail!("cannot finalize before all accusations are resolved");
+        }
+        let completing_receivers =
+            usize::from(self.reshare_senders.new_parameters.number_of_parties)
+                - self.excluded_verdict_parties.len();
+        if completing_receivers < usize::from(self.reshare_senders.new_parameters.threshold) {
+            eyre::bail!("fewer than the threshold receivers remain in the blame round");
         }
         let qualified = self
             .reshare_senders
@@ -265,6 +315,7 @@ impl<C: CurveGroup> ReShareBlameRound<C> {
                 pk: self.reshare_senders.pk,
             },
             disqualified_parties: self.disqualified_senders.into_iter().collect(),
+            excluded_verdict_parties: self.excluded_verdict_parties.into_iter().collect(),
         })
     }
 

--- a/threshold-eddsa-babyjubjub/src/reshare/blame.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/blame.rs
@@ -1,0 +1,276 @@
+//! Optional public complaint round for resharing.
+//!
+//! New parties first broadcast either `Ok` or the old senders whose private evaluations failed.
+//! Every accused old sender then reveals the committed evaluation for each accuser.
+
+use crate::{
+    keygen::{
+        Parameters,
+        blame::{BlameResult, BlameRevelation, BlameVerdict},
+        finished::Finished,
+    },
+    reshare::{receiver::ReShareProtocolReceiver, sender_set::ReShareSenderSet},
+    shamir::utils,
+};
+use ark_ec::CurveGroup;
+use ark_ff::Zero;
+use eyre::Result;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use uuid::Uuid;
+
+/// Receiver-side state for the optional resharing blame round.
+pub struct ReShareBlameRound<C: CurveGroup> {
+    my_idx: u16,
+    received_shares: HashMap<u16, (C::ScalarField, Vec<C::Affine>)>,
+    reshare_senders: ReShareSenderSet<C>,
+    session_id: Uuid,
+    verdicts: BTreeMap<u16, BlameVerdict>,
+    resolved_senders: BTreeSet<u16>,
+    disqualified_senders: BTreeSet<u16>,
+}
+
+impl<C: CurveGroup> ReShareBlameRound<C> {
+    pub(crate) fn new(receiver: ReShareProtocolReceiver<C>) -> Result<Self> {
+        if !receiver.can_advance() {
+            eyre::bail!("cannot enter reshare blame round before all sender messages arrive");
+        }
+        let own_verdict = BlameVerdict {
+            session_id: receiver.session_id,
+            blamed_parties: receiver.failed_senders,
+        };
+        let mut verdicts = BTreeMap::new();
+        verdicts.insert(receiver.my_idx, own_verdict);
+
+        Ok(Self {
+            my_idx: receiver.my_idx,
+            received_shares: receiver.received_shares,
+            reshare_senders: receiver.reshare_senders,
+            session_id: receiver.session_id,
+            verdicts,
+            resolved_senders: BTreeSet::new(),
+            disqualified_senders: BTreeSet::new(),
+        })
+    }
+
+    /// Return this new party's `Ok` or blame-set broadcast.
+    #[must_use]
+    pub fn verdict(&self) -> BlameVerdict {
+        self.verdicts[&self.my_idx].clone()
+    }
+
+    /// Add another new party's verdict broadcast.
+    ///
+    /// # Errors
+    /// Returns an error for invalid or duplicate senders, a wrong session, or a blamed ID outside
+    /// the selected old-sender set.
+    pub fn add_verdict(&mut self, from: u16, verdict: BlameVerdict) -> Result<()> {
+        if from == 0 {
+            eyre::bail!("party index must be non-zero",);
+        }
+        if from > self.reshare_senders.new_parameters.number_of_parties {
+            eyre::bail!("party index {from} invalid for parameters",);
+        }
+        if from == self.my_idx {
+            eyre::bail!("do not add own verdict");
+        }
+        if self.verdicts.contains_key(&from) {
+            eyre::bail!("already added verdict from new party {from}");
+        }
+        if verdict.session_id != self.session_id {
+            eyre::bail!("session id mismatch in verdict from new party {from}");
+        }
+        if verdict
+            .blamed_parties
+            .iter()
+            .any(|sender| !self.reshare_senders.senders.contains_key(sender))
+        {
+            eyre::bail!("verdict from new party {from} blames an unselected old sender");
+        }
+        self.verdicts.insert(from, verdict);
+        Ok(())
+    }
+
+    /// New parties whose verdict broadcasts are still missing.
+    #[must_use]
+    pub fn missing_verdicts(&self) -> Vec<u16> {
+        (1..=self.reshare_senders.new_parameters.number_of_parties)
+            .filter(|party| !self.verdicts.contains_key(party))
+            .collect()
+    }
+
+    /// Whether every party's `Ok` or blame-set broadcast has been received.
+    #[must_use]
+    pub fn verdicts_complete(&self) -> bool {
+        self.verdicts.len() == usize::from(self.reshare_senders.new_parameters.number_of_parties)
+    }
+
+    /// Map every accused old sender to the new parties accusing it.
+    ///
+    /// # Errors
+    /// Returns an error until every new party's verdict has arrived.
+    pub fn accusations(&self) -> Result<BTreeMap<u16, BTreeSet<u16>>> {
+        if !self.verdicts_complete() {
+            eyre::bail!("cannot determine accusations before all verdicts are received");
+        }
+        let mut accusations = BTreeMap::<u16, BTreeSet<u16>>::new();
+        for (&receiver, verdict) in &self.verdicts {
+            for &sender in &verdict.blamed_parties {
+                accusations.entry(sender).or_default().insert(receiver);
+            }
+        }
+        Ok(accusations)
+    }
+
+    /// Add and verify an accused old sender's public revelation.
+    ///
+    /// A valid revelation replaces this receiver's private value where applicable. A malformed
+    /// broadcast or failed polynomial equation disqualifies the old sender.
+    ///
+    /// # Errors
+    /// Returns an error for an unselected or unaccused sender or duplicate resolution.
+    pub fn add_revelation(&mut self, from: u16, revelation: &BlameRevelation<C>) -> Result<()> {
+        if !self.reshare_senders.senders.contains_key(&from) {
+            eyre::bail!("old party {from} is not a selected sender");
+        }
+        let accusations = self.accusations()?;
+        let Some(expected_receivers) = accusations.get(&from) else {
+            eyre::bail!("old sender {from} was not accused");
+        };
+        if self.resolved_senders.contains(&from) {
+            eyre::bail!("old sender {from}'s accusation was already resolved");
+        }
+        let receivers = revelation
+            .shares
+            .iter()
+            .map(|share| share.receiver)
+            .collect::<BTreeSet<_>>();
+        let structurally_valid = revelation.session_id == self.session_id
+            && receivers.len() == revelation.shares.len()
+            && &receivers == expected_receivers;
+        let equations_valid = structurally_valid
+            && revelation.shares.iter().all(|share| {
+                utils::verify_polynomial_evaluation::<C>(
+                    &self.received_shares[&from].1,
+                    share.receiver,
+                    &share.share,
+                )
+            });
+        if equations_valid {
+            if let Some(share) = revelation
+                .shares
+                .iter()
+                .find(|share| share.receiver == self.my_idx)
+                && let Some(received) = self.received_shares.get_mut(&from)
+            {
+                received.0 = share.share;
+            }
+        } else {
+            self.disqualified_senders.insert(from);
+        }
+        self.resolved_senders.insert(from);
+        Ok(())
+    }
+
+    /// Disqualify an accused sender that missed an externally enforced revelation deadline.
+    ///
+    /// # Errors
+    /// Returns an error for an unaccused sender or duplicate resolution.
+    pub fn disqualify_missing_sender(&mut self, sender: u16) -> Result<()> {
+        if !self.accusations()?.contains_key(&sender) {
+            eyre::bail!("old sender {sender} was not accused");
+        }
+        if !self.resolved_senders.insert(sender) {
+            eyre::bail!("old sender {sender}'s accusation was already resolved");
+        }
+        self.disqualified_senders.insert(sender);
+        Ok(())
+    }
+
+    /// Accused old senders whose revelation or timeout resolution is still missing.
+    ///
+    /// # Errors
+    /// Returns an error until all verdicts arrive.
+    pub fn missing_revelations(&self) -> Result<Vec<u16>> {
+        Ok(self
+            .accusations()?
+            .keys()
+            .filter(|sender| !self.resolved_senders.contains(sender))
+            .copied()
+            .collect())
+    }
+
+    /// Finalize using the surviving old senders and freshly recomputed Lagrange coefficients.
+    ///
+    /// # Errors
+    /// Returns an error while messages remain unresolved, if fewer than the old threshold senders
+    /// survive, or if their constant commitments do not reconstruct the original public key.
+    pub fn finalize(self) -> Result<BlameResult<C>> {
+        if !self.verdicts_complete() {
+            eyre::bail!("cannot finalize before all verdicts are received");
+        }
+        if !self.missing_revelations()?.is_empty() {
+            eyre::bail!("cannot finalize before all accusations are resolved");
+        }
+        let qualified = self
+            .reshare_senders
+            .senders
+            .keys()
+            .filter(|sender| !self.disqualified_senders.contains(sender))
+            .copied()
+            .collect::<Vec<_>>();
+        if qualified.len() < usize::from(self.reshare_senders.old_parameters.threshold) {
+            eyre::bail!("not enough qualified old senders remain after blame round");
+        }
+
+        let lagrange = qualified
+            .iter()
+            .map(|sender| {
+                (
+                    *sender,
+                    utils::single_lagrange_from_coeff::<C::ScalarField, _>(*sender, &qualified),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+
+        let my_secret_key_share = qualified
+            .iter()
+            .fold(C::ScalarField::zero(), |acc, sender| {
+                acc + lagrange[sender] * self.received_shares[sender].0
+            });
+        let public_key = qualified.iter().fold(C::zero(), |acc, sender| {
+            acc + self.received_shares[sender].1[0] * lagrange[sender]
+        });
+        if public_key.into_affine() != self.reshare_senders.pk {
+            eyre::bail!("qualified old senders do not reconstruct the original public key");
+        }
+
+        let public_key_shares = (1..=self.reshare_senders.new_parameters.number_of_parties)
+            .map(|receiver| {
+                let share = qualified.iter().fold(C::zero(), |acc, sender| {
+                    acc + utils::evaluate_polynomial_in_exponent::<C>(
+                        &self.received_shares[sender].1,
+                        receiver,
+                    ) * lagrange[sender]
+                });
+                (receiver, share.into_affine())
+            })
+            .collect();
+
+        Ok(BlameResult {
+            finished: Finished {
+                my_idx: self.my_idx,
+                session_id: self.session_id,
+                sk_share: my_secret_key_share,
+                pk_shares: public_key_shares,
+                pk: self.reshare_senders.pk,
+            },
+            disqualified_parties: self.disqualified_senders.into_iter().collect(),
+        })
+    }
+
+    /// Parameters of the old sharing.
+    #[must_use]
+    pub fn old_parameters(&self) -> Parameters {
+        self.reshare_senders.old_parameters
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/reshare/blame.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/blame.rs
@@ -245,6 +245,11 @@ impl<C: CurveGroup> ReShareBlameRound<C> {
 
     /// Finalize using the surviving old senders and freshly recomputed Lagrange coefficients.
     ///
+    /// The public-key check below is not an agreement check: every valid sender set reconstructs the
+    /// same key. Compare
+    /// [`Finished::agreement_digest`](crate::keygen::finished::Finished::agreement_digest) across
+    /// receivers before erasing the old shares.
+    ///
     /// # Errors
     /// Returns an error while messages remain unresolved, if fewer than the old threshold senders
     /// survive, or if their constant commitments do not reconstruct the original public key.
@@ -313,6 +318,8 @@ impl<C: CurveGroup> ReShareBlameRound<C> {
                 sk_share: my_secret_key_share,
                 pk_shares: public_key_shares,
                 pk: self.reshare_senders.pk,
+                // Old-committee indices, ascending because `senders` is a `BTreeMap`.
+                contributing_parties: qualified,
             },
             disqualified_parties: self.disqualified_senders.into_iter().collect(),
             excluded_verdict_parties: self.excluded_verdict_parties.into_iter().collect(),

--- a/threshold-eddsa-babyjubjub/src/reshare/mod.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/mod.rs
@@ -4,6 +4,7 @@
 //! currently holding a key hand it over to a new, possibly differently sized, set of parties. The
 //! signing key itself is unchanged, only the Shamir sharing of it is replaced.
 
+pub mod blame;
 pub mod receiver;
 pub mod sender;
 pub mod sender_set;

--- a/threshold-eddsa-babyjubjub/src/reshare/mod.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/mod.rs
@@ -1,0 +1,14 @@
+//! Re-sharing of a threshold `EdDSA` key to a new set of parties.
+//!
+//! This module implements the `ReShare` protocol, which lets a threshold sized subset of the parties
+//! currently holding a key hand it over to a new, possibly differently sized, set of parties. The
+//! signing key itself is unchanged, only the Shamir sharing of it is replaced.
+
+pub mod receiver;
+pub mod sender;
+pub mod sender_set;
+#[cfg(test)]
+pub mod test;
+
+pub(crate) type BroadcastMessage<C> = crate::keygen::round1::RoundOneBroadcast<C>;
+pub(crate) type PartyMessage<C> = crate::keygen::round2::RoundTwoCommunication<C>;

--- a/threshold-eddsa-babyjubjub/src/reshare/receiver.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/receiver.rs
@@ -7,14 +7,15 @@
 use crate::{
     keygen::{MaliciousPartyError, finished::Finished, schnorr},
     reshare::{
-        BroadcastMessage, PartyMessage, sender::ReShareProtocolSender, sender_set::ReShareSenderSet,
+        BroadcastMessage, PartyMessage, blame::ReShareBlameRound, sender::ReShareProtocolSender,
+        sender_set::ReShareSenderSet,
     },
     shamir::utils,
 };
 use ark_ec::CurveGroup;
 use ark_ff::Zero;
 use eyre::Result;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use uuid::Uuid;
 
 /// A receiver in the `ReShare` protocol is a party in the new set of parties.
@@ -23,6 +24,7 @@ pub struct ReShareProtocolReceiver<C: CurveGroup> {
     pub(crate) received_shares: HashMap<u16, (C::ScalarField, Vec<C::Affine>)>,
     pub(crate) reshare_senders: ReShareSenderSet<C>,
     pub(crate) session_id: Uuid,
+    pub(crate) failed_senders: BTreeSet<u16>,
 }
 
 impl<C: CurveGroup> ReShareProtocolReceiver<C> {
@@ -51,6 +53,7 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
             received_shares: HashMap::new(),
             reshare_senders,
             session_id,
+            failed_senders: BTreeSet::new(),
         })
     }
 
@@ -98,10 +101,7 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
             eyre::bail!(MaliciousPartyError::new(from as usize));
         }
 
-        if self.session_id != commitments.session_id {
-            eyre::bail!("session id mismatch for party {from}");
-        }
-        if self.session_id != share.session_id {
+        if self.session_id != commitments.session_id || self.session_id != share.session_id {
             eyre::bail!("session id mismatch for party {from}");
         }
 
@@ -141,6 +141,85 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
         self.received_shares
             .insert(from, (share.secret_share, commitments.commitments.0));
 
+        Ok(())
+    }
+
+    /// Add old-party communication while retaining an invalid polynomial evaluation for the
+    /// optional public blame round.
+    ///
+    /// All broadcast commitments and proofs must still be valid. Only a private share that fails
+    /// its committed polynomial equation is converted into a complaint.
+    ///
+    /// # Errors
+    /// Returns an error for invalid sender metadata, commitments, proof of possession, or session.
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "Keeps consistency with add_old_party_communication"
+    )]
+    pub fn add_old_party_communication_for_blame(
+        &mut self,
+        from: u16,
+        commitments: BroadcastMessage<C>,
+        share: PartyMessage<C>,
+    ) -> Result<()> {
+        if from == 0 {
+            eyre::bail!("party index must be non-zero",);
+        }
+        if from > self.reshare_senders.old_parameters.number_of_parties {
+            eyre::bail!("party index {from} invalid for old parameters",);
+        }
+
+        if !self.reshare_senders.senders.contains_key(&from) {
+            eyre::bail!("party index {from} is not part of the set of ReShare senders");
+        }
+        if self.received_shares.contains_key(&from) {
+            eyre::bail!("already added message for party {from}");
+        }
+
+        if commitments.commitments.len()
+            != usize::from(self.reshare_senders.new_parameters.threshold)
+        {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+
+        if self.session_id != commitments.session_id || self.session_id != share.session_id {
+            eyre::bail!("session id mismatch for party {from}");
+        }
+
+        let pk_share = self.reshare_senders.senders[&from];
+
+        // verify ZK proof
+        let context = schnorr::proof_context(
+            Self::CONTEXT_DOMAIN,
+            self.session_id,
+            &[
+                self.reshare_senders.old_parameters,
+                self.reshare_senders.new_parameters,
+            ],
+        );
+        if !commitments.nizk.verify(
+            &context,
+            from,
+            &commitments.commitments[0],
+            &commitments.commitments[1..],
+        ) {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+
+        // Commitment must match the public key share of the sender
+        if commitments.commitments[0] != pk_share {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+
+        if !utils::verify_polynomial_evaluation::<C>(
+            &commitments.commitments,
+            self.my_idx,
+            &share.secret_share,
+        ) {
+            self.failed_senders.insert(from);
+        }
+        self.received_shares
+            .insert(from, (share.secret_share, commitments.commitments.0));
         Ok(())
     }
 
@@ -237,5 +316,13 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
             pk_shares: public_key_shares,
             pk: public_key,
         })
+    }
+
+    /// Enter the optional public blame round after collecting every selected sender's messages.
+    ///
+    /// # Errors
+    /// Returns an error unless all selected sender communications have been collected.
+    pub fn blame_round(self) -> Result<ReShareBlameRound<C>> {
+        ReShareBlameRound::new(self)
     }
 }

--- a/threshold-eddsa-babyjubjub/src/reshare/receiver.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/receiver.rs
@@ -99,10 +99,10 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
         }
 
         if self.session_id != commitments.session_id {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
+            eyre::bail!("session id mismatch for party {from}");
         }
         if self.session_id != share.session_id {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
+            eyre::bail!("session id mismatch for party {from}");
         }
 
         let pk_share = self.reshare_senders.senders[&from];

--- a/threshold-eddsa-babyjubjub/src/reshare/receiver.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/receiver.rs
@@ -5,7 +5,10 @@
 //! coefficients of the senders, into its own share of the unchanged signing key.
 
 use crate::{
-    keygen::{MaliciousPartyError, finished::Finished, schnorr},
+    keygen::{
+        MalformedMessageError, MaliciousPartyError, MessageError, MessageResult,
+        finished::Finished, schnorr,
+    },
     reshare::{
         BroadcastMessage, PartyMessage, blame::ReShareBlameRound, sender::ReShareProtocolSender,
         sender_set::ReShareSenderSet,
@@ -65,6 +68,9 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
 
     /// Construct a [`ReShareProtocolReceiver`] for a party in the new set of parties with new index `my_idx`.
     ///
+    /// `session_id` must be the same for every participant *and* globally unique per run; see
+    /// [`ReShareProtocolSender::new`] for why reuse lets an honest sender be framed.
+    ///
     /// # Errors
     /// Returns an error if `my_idx` is zero or larger than the number of parties allowed by the new
     /// [`Parameters`](crate::keygen::Parameters).
@@ -99,77 +105,31 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
     /// consistent with the share of the public key the sender was registered with.
     ///
     /// # Errors
-    /// Returns a [`MaliciousPartyError`] identifying the offending party if its broadcast contains
-    /// the wrong number of commitments, either message carries a different session id, the proof of
-    /// knowledge is invalid, the commitment to the constant term does not match the sender's share
-    /// of the public key, or the secret share does not verify against the commitments.
-    /// All other errors indicate an invalid `from` index and are usually the fault of the local
-    /// party.
+    /// Returns [`MessageError::MaliciousParty`] if the proof of knowledge is invalid, the
+    /// constant-term commitment does not match the sender's registered public-key share, or the
+    /// secret share does not verify against the commitments; all three attribute blame.
+    /// [`MessageError::Malformed`] (wrong commitment count or session id) does not — it is usually a
+    /// local configuration mismatch. [`MessageError::LocalFault`] means an unselected sender or a
+    /// duplicate delivery.
     pub fn add_old_party_communication(
         &mut self,
         from: u16,
         commitments: BroadcastMessage<C>,
         share: &PartyMessage<C>,
-    ) -> Result<()> {
-        if from == 0 {
-            eyre::bail!("party index must be non-zero",);
-        }
-        if from > self.reshare_senders.old_parameters.number_of_parties {
-            eyre::bail!("party index {from} invalid for old parameters",);
-        }
-
-        if !self.reshare_senders.senders.contains_key(&from) {
-            eyre::bail!("party index {from} is not part of the set of ReShare senders");
-        }
-        if self.received_shares.contains_key(&from) {
-            eyre::bail!("already added message for party {from}");
-        }
-
-        if commitments.commitments.len()
-            != usize::from(self.reshare_senders.new_parameters.threshold)
-        {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
-        }
-
-        if self.session_id != commitments.session_id || self.session_id != share.session_id {
-            eyre::bail!("session id mismatch for party {from}");
-        }
-
-        let pk_share = self.reshare_senders.senders[&from];
-
-        // verify ZK proof
-        let context = schnorr::proof_context(
-            Self::CONTEXT_DOMAIN,
-            self.session_id,
-            &[
-                self.reshare_senders.old_parameters,
-                self.reshare_senders.new_parameters,
-            ],
-        );
-        if !commitments.nizk.verify(
-            &context,
-            from,
-            &commitments.commitments[0],
-            &commitments.commitments[1..],
-        ) {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
-        }
-
-        // Commitment must match the public key share of the sender
-        if commitments.commitments[0] != pk_share {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
-        }
+    ) -> MessageResult<()> {
+        self.validate_broadcast(from, &commitments)?;
+        self.validate_share_session(from, share)?;
 
         if !utils::verify_polynomial_evaluation::<C>(
-            &commitments.commitments.0,
+            &commitments.commitments,
             self.my_idx,
             &share.secret_share,
         ) {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
+            return Err(MaliciousPartyError::new(from as usize).into());
         }
 
         self.received_shares
-            .insert(from, (share.secret_share, commitments.commitments.0));
+            .insert(from, (share.secret_share, commitments.commitments));
 
         Ok(())
     }
@@ -181,61 +141,17 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
     /// its committed polynomial equation is converted into a complaint.
     ///
     /// # Errors
-    /// Returns an error for invalid sender metadata, commitments, proof of possession, or session.
+    /// As [`ReShareProtocolReceiver::add_old_party_communication`], except that a private evaluation
+    /// failing its polynomial equation becomes a recorded complaint rather than
+    /// [`MessageError::MaliciousParty`].
     pub fn add_old_party_communication_for_blame(
         &mut self,
         from: u16,
         commitments: BroadcastMessage<C>,
         share: &PartyMessage<C>,
-    ) -> Result<()> {
-        if from == 0 {
-            eyre::bail!("party index must be non-zero",);
-        }
-        if from > self.reshare_senders.old_parameters.number_of_parties {
-            eyre::bail!("party index {from} invalid for old parameters",);
-        }
-
-        if !self.reshare_senders.senders.contains_key(&from) {
-            eyre::bail!("party index {from} is not part of the set of ReShare senders");
-        }
-        if self.received_shares.contains_key(&from) {
-            eyre::bail!("already added message for party {from}");
-        }
-
-        if commitments.commitments.len()
-            != usize::from(self.reshare_senders.new_parameters.threshold)
-        {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
-        }
-
-        if self.session_id != commitments.session_id || self.session_id != share.session_id {
-            eyre::bail!("session id mismatch for party {from}");
-        }
-
-        let pk_share = self.reshare_senders.senders[&from];
-
-        // verify ZK proof
-        let context = schnorr::proof_context(
-            Self::CONTEXT_DOMAIN,
-            self.session_id,
-            &[
-                self.reshare_senders.old_parameters,
-                self.reshare_senders.new_parameters,
-            ],
-        );
-        if !commitments.nizk.verify(
-            &context,
-            from,
-            &commitments.commitments[0],
-            &commitments.commitments[1..],
-        ) {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
-        }
-
-        // Commitment must match the public key share of the sender
-        if commitments.commitments[0] != pk_share {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
-        }
+    ) -> MessageResult<()> {
+        self.validate_broadcast(from, &commitments)?;
+        self.validate_share_session(from, share)?;
 
         if !utils::verify_polynomial_evaluation::<C>(
             &commitments.commitments,
@@ -245,7 +161,7 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
             self.failed_senders.insert(from);
         }
         self.received_shares
-            .insert(from, (share.secret_share, commitments.commitments.0));
+            .insert(from, (share.secret_share, commitments.commitments));
         Ok(())
     }
 
@@ -264,29 +180,64 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
     /// This lets the protocol enter the public blame round, where the sender can reveal the
     /// committed evaluation or be disqualified after an externally agreed deadline.
     ///
+    /// Use this when the sender's broadcast arrived and only its private evaluation is missing.
+    /// Choosing between this and [`ReShareProtocolReceiver::disqualify_missing_sender`] changes the
+    /// surviving sender set, so it must be an externally agreed decision — see that method.
+    ///
     /// # Errors
-    /// Returns an error for an invalid sender, previously received communication, or an invalid
-    /// broadcast, proof, session, or constant commitment.
+    /// As [`ReShareProtocolReceiver::add_old_party_communication`], minus the private-share checks.
     pub fn complain_missing_share(
         &mut self,
         from: u16,
         commitments: BroadcastMessage<C>,
-    ) -> Result<()> {
-        if from == 0
-            || from > self.reshare_senders.old_parameters.number_of_parties
-            || !self.reshare_senders.senders.contains_key(&from)
-        {
-            eyre::bail!("invalid selected old sender");
+    ) -> MessageResult<()> {
+        self.validate_broadcast(from, &commitments)?;
+        self.failed_senders.insert(from);
+        self.received_shares
+            .insert(from, (C::ScalarField::zero(), commitments.commitments));
+        Ok(())
+    }
+
+    /// Validates a sender's broadcast, shared by every intake path. The sender and framing checks
+    /// attribute no blame; the two cryptographic checks bind the broadcast to the public-key share
+    /// the sender was registered with and do.
+    fn validate_broadcast(
+        &self,
+        from: u16,
+        commitments: &BroadcastMessage<C>,
+    ) -> MessageResult<()> {
+        if from == 0 || from > self.reshare_senders.old_parameters.number_of_parties {
+            return Err(MessageError::local(format!(
+                "party index {from} invalid for old parameters"
+            )));
+        }
+        if !self.reshare_senders.senders.contains_key(&from) {
+            return Err(MessageError::local(format!(
+                "party index {from} is not part of the set of ReShare senders"
+            )));
         }
         if self.received_shares.contains_key(&from) {
-            eyre::bail!("already added communication for sender {from}");
+            return Err(MessageError::local(format!(
+                "already added communication for sender {from}"
+            )));
         }
         if commitments.commitments.len()
             != usize::from(self.reshare_senders.new_parameters.threshold)
-            || commitments.session_id != self.session_id
         {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
+            return Err(MalformedMessageError::new(
+                from as usize,
+                "commitment count does not match the local new threshold",
+            )
+            .into());
         }
+        if commitments.session_id != self.session_id {
+            return Err(MalformedMessageError::new(
+                from as usize,
+                "broadcast session id does not match the local session",
+            )
+            .into());
+        }
+
         let context = schnorr::proof_context(
             Self::CONTEXT_DOMAIN,
             self.session_id,
@@ -300,17 +251,35 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
             from,
             &commitments.commitments[0],
             &commitments.commitments[1..],
+            // Commitment must match the public key share of the sender
         ) || commitments.commitments[0] != self.reshare_senders.senders[&from]
         {
-            eyre::bail!(MaliciousPartyError::new(from as usize));
+            return Err(MaliciousPartyError::new(from as usize).into());
         }
-        self.failed_senders.insert(from);
-        self.received_shares
-            .insert(from, (C::ScalarField::zero(), commitments.commitments.0));
+        Ok(())
+    }
+
+    fn validate_share_session(&self, from: u16, share: &PartyMessage<C>) -> MessageResult<()> {
+        if share.session_id != self.session_id {
+            return Err(MalformedMessageError::new(
+                from as usize,
+                "private evaluation session id does not match the local session",
+            )
+            .into());
+        }
         Ok(())
     }
 
     /// Apply an externally agreed disqualification when a sender supplied no usable broadcast.
+    ///
+    /// This drops `from` from the sender set, which changes every remaining Lagrange coefficient and
+    /// therefore the polynomial the new sharing lies on. Since every valid sender set reconstructs
+    /// the same public key, a receiver that disqualifies a different set than its peers still passes
+    /// [`ReShareProtocolReceiver::finalize`] — see
+    /// [`Finished::agreement_digest`](crate::keygen::finished::Finished::agreement_digest). The
+    /// overlap with [`ReShareProtocolReceiver::complain_missing_share`] is the trap: both are
+    /// reachable whenever nothing was recorded for a sender, so derive the choice from an externally
+    /// agreed decision, never from a local timeout.
     ///
     /// # Errors
     /// Returns an error if communication was already received, the sender was not selected, or
@@ -341,6 +310,12 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
     ///
     /// The resulting [`Finished`] state holds this party's share of the unchanged signing key under
     /// the new [`Parameters`](crate::keygen::Parameters).
+    ///
+    /// The public-key check below catches a wrong sender *contribution* but is not an agreement
+    /// check: every valid sender set reconstructs the same key, so receivers that used different sets
+    /// both succeed here. Compare
+    /// [`Finished::agreement_digest`](crate::keygen::finished::Finished::agreement_digest) across
+    /// receivers before erasing the old shares.
     ///
     /// # Errors
     /// Returns an error if the communication of not all old parties has been added yet, i.e., if
@@ -415,6 +390,8 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
             sk_share: my_secret_key_share,
             pk_shares: public_key_shares,
             pk: public_key,
+            // Old-committee indices, ascending because `senders` is a `BTreeMap`.
+            contributing_parties: old_parties,
         })
     }
 

--- a/threshold-eddsa-babyjubjub/src/reshare/receiver.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/receiver.rs
@@ -5,8 +5,10 @@
 //! coefficients of the senders, into its own share of the unchanged signing key.
 
 use crate::{
-    keygen::{MaliciousPartyError, finished::Finished},
-    reshare::{BroadcastMessage, PartyMessage, sender_set::ReShareSenderSet},
+    keygen::{MaliciousPartyError, finished::Finished, schnorr},
+    reshare::{
+        BroadcastMessage, PartyMessage, sender::ReShareProtocolSender, sender_set::ReShareSenderSet,
+    },
     shamir::utils,
 };
 use ark_ec::CurveGroup;
@@ -24,6 +26,8 @@ pub struct ReShareProtocolReceiver<C: CurveGroup> {
 }
 
 impl<C: CurveGroup> ReShareProtocolReceiver<C> {
+    const CONTEXT_DOMAIN: &'static [u8] = ReShareProtocolSender::<C>::CONTEXT_DOMAIN;
+
     /// Construct a [`ReShareProtocolReceiver`] for a party in the new set of parties with new index `my_idx`.
     ///
     /// # Errors
@@ -40,6 +44,7 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
         if my_idx > reshare_senders.new_parameters.number_of_parties {
             eyre::bail!("provided party index {my_idx} is larger than new parameters allow",);
         }
+        reshare_senders.correct()?;
 
         Ok(ReShareProtocolReceiver {
             my_idx,
@@ -103,7 +108,20 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
         let pk_share = self.reshare_senders.senders[&from];
 
         // verify ZK proof
-        if !commitments.nizk.verify(from, &pk_share) {
+        let context = schnorr::proof_context(
+            Self::CONTEXT_DOMAIN,
+            self.session_id,
+            &[
+                self.reshare_senders.old_parameters,
+                self.reshare_senders.new_parameters,
+            ],
+        );
+        if !commitments.nizk.verify(
+            &context,
+            from,
+            &commitments.commitments[0],
+            &commitments.commitments[1..],
+        ) {
             eyre::bail!(MaliciousPartyError::new(from as usize));
         }
 

--- a/threshold-eddsa-babyjubjub/src/reshare/receiver.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/receiver.rs
@@ -16,15 +16,48 @@ use ark_ec::CurveGroup;
 use ark_ff::Zero;
 use eyre::Result;
 use std::collections::{BTreeSet, HashMap};
+use std::ops::{Deref, DerefMut};
 use uuid::Uuid;
 
 /// A receiver in the `ReShare` protocol is a party in the new set of parties.
 pub struct ReShareProtocolReceiver<C: CurveGroup> {
     pub(crate) my_idx: u16,
-    pub(crate) received_shares: HashMap<u16, (C::ScalarField, Vec<C::Affine>)>,
+    pub(crate) received_shares: ReceivedShares<C>,
     pub(crate) reshare_senders: ReShareSenderSet<C>,
     pub(crate) session_id: Uuid,
     pub(crate) failed_senders: BTreeSet<u16>,
+    pub(crate) pre_disqualified_senders: BTreeSet<u16>,
+}
+
+pub(crate) struct ReceivedShares<C: CurveGroup>(
+    pub(crate) HashMap<u16, (C::ScalarField, Vec<C::Affine>)>,
+);
+
+impl<C: CurveGroup> Deref for ReceivedShares<C> {
+    type Target = HashMap<u16, (C::ScalarField, Vec<C::Affine>)>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<C: CurveGroup> DerefMut for ReceivedShares<C> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<C: CurveGroup> Drop for ReceivedShares<C> {
+    #[allow(
+        clippy::iter_over_hash_type,
+        reason = "zeroization order has no semantic effect"
+    )]
+    fn drop(&mut self) {
+        use zeroize::Zeroize as _;
+        for (share, _) in self.0.values_mut() {
+            share.zeroize();
+        }
+    }
 }
 
 impl<C: CurveGroup> ReShareProtocolReceiver<C> {
@@ -50,10 +83,11 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
 
         Ok(ReShareProtocolReceiver {
             my_idx,
-            received_shares: HashMap::new(),
+            received_shares: ReceivedShares(HashMap::new()),
             reshare_senders,
             session_id,
             failed_senders: BTreeSet::new(),
+            pre_disqualified_senders: BTreeSet::new(),
         })
     }
 
@@ -71,15 +105,11 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
     /// of the public key, or the secret share does not verify against the commitments.
     /// All other errors indicate an invalid `from` index and are usually the fault of the local
     /// party.
-    #[expect(
-        clippy::needless_pass_by_value,
-        reason = "Keeps consistency with the broadcast message, which is consumed"
-    )]
     pub fn add_old_party_communication(
         &mut self,
         from: u16,
         commitments: BroadcastMessage<C>,
-        share: PartyMessage<C>,
+        share: &PartyMessage<C>,
     ) -> Result<()> {
         if from == 0 {
             eyre::bail!("party index must be non-zero",);
@@ -152,15 +182,11 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
     ///
     /// # Errors
     /// Returns an error for invalid sender metadata, commitments, proof of possession, or session.
-    #[expect(
-        clippy::needless_pass_by_value,
-        reason = "Keeps consistency with add_old_party_communication"
-    )]
     pub fn add_old_party_communication_for_blame(
         &mut self,
         from: u16,
         commitments: BroadcastMessage<C>,
-        share: PartyMessage<C>,
+        share: &PartyMessage<C>,
     ) -> Result<()> {
         if from == 0 {
             eyre::bail!("party index must be non-zero",);
@@ -233,6 +259,77 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
             .collect()
     }
 
+    /// Register a valid sender broadcast but complain that its private evaluation was missing.
+    ///
+    /// This lets the protocol enter the public blame round, where the sender can reveal the
+    /// committed evaluation or be disqualified after an externally agreed deadline.
+    ///
+    /// # Errors
+    /// Returns an error for an invalid sender, previously received communication, or an invalid
+    /// broadcast, proof, session, or constant commitment.
+    pub fn complain_missing_share(
+        &mut self,
+        from: u16,
+        commitments: BroadcastMessage<C>,
+    ) -> Result<()> {
+        if from == 0
+            || from > self.reshare_senders.old_parameters.number_of_parties
+            || !self.reshare_senders.senders.contains_key(&from)
+        {
+            eyre::bail!("invalid selected old sender");
+        }
+        if self.received_shares.contains_key(&from) {
+            eyre::bail!("already added communication for sender {from}");
+        }
+        if commitments.commitments.len()
+            != usize::from(self.reshare_senders.new_parameters.threshold)
+            || commitments.session_id != self.session_id
+        {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+        let context = schnorr::proof_context(
+            Self::CONTEXT_DOMAIN,
+            self.session_id,
+            &[
+                self.reshare_senders.old_parameters,
+                self.reshare_senders.new_parameters,
+            ],
+        );
+        if !commitments.nizk.verify(
+            &context,
+            from,
+            &commitments.commitments[0],
+            &commitments.commitments[1..],
+        ) || commitments.commitments[0] != self.reshare_senders.senders[&from]
+        {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+        self.failed_senders.insert(from);
+        self.received_shares
+            .insert(from, (C::ScalarField::zero(), commitments.commitments.0));
+        Ok(())
+    }
+
+    /// Apply an externally agreed disqualification when a sender supplied no usable broadcast.
+    ///
+    /// # Errors
+    /// Returns an error if communication was already received, the sender was not selected, or
+    /// removing it would leave an invalid sender set that no longer reconstructs the old key.
+    pub fn disqualify_missing_sender(&mut self, from: u16) -> Result<()> {
+        if self.received_shares.contains_key(&from) {
+            eyre::bail!("sender {from}'s communication was already received");
+        }
+        let Some(removed_share) = self.reshare_senders.senders.remove(&from) else {
+            eyre::bail!("party {from} is not a selected old sender");
+        };
+        if let Err(error) = self.reshare_senders.correct() {
+            self.reshare_senders.senders.insert(from, removed_share);
+            eyre::bail!("cannot disqualify sender while preserving the old key: {error}");
+        }
+        self.pre_disqualified_senders.insert(from);
+        Ok(())
+    }
+
     /// Indicates if the protocol is ready to advance into the next state.
     /// See [`ReShareProtocolReceiver::get_missing_parties`] for parties we are still missing information from.
     pub fn can_advance(&self) -> bool {
@@ -252,6 +349,9 @@ impl<C: CurveGroup> ReShareProtocolReceiver<C> {
     pub fn finalize(self) -> Result<Finished<C>> {
         if !self.can_advance() {
             eyre::bail!("cannot finalize, not all messages received");
+        }
+        if !self.failed_senders.is_empty() {
+            eyre::bail!("cannot finalize with unresolved complaints; enter the blame round");
         }
 
         // The Lagrange coefficients are relative to the set of parties that actually took part in

--- a/threshold-eddsa-babyjubjub/src/reshare/receiver.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/receiver.rs
@@ -1,0 +1,223 @@
+//! The receivers in the `ReShare` protocol.
+//!
+//! A receiver is a party in the new set of parties. It checks the shares it receives from the old
+//! parties against their broadcast commitments and combines them, weighted with the Lagrange
+//! coefficients of the senders, into its own share of the unchanged signing key.
+
+use crate::{
+    keygen::{MaliciousPartyError, finished::Finished},
+    reshare::{BroadcastMessage, PartyMessage, sender_set::ReShareSenderSet},
+    shamir::utils,
+};
+use ark_ec::CurveGroup;
+use ark_ff::Zero;
+use eyre::Result;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// A receiver in the `ReShare` protocol is a party in the new set of parties.
+pub struct ReShareProtocolReceiver<C: CurveGroup> {
+    pub(crate) my_idx: u16,
+    pub(crate) received_shares: HashMap<u16, (C::ScalarField, Vec<C::Affine>)>,
+    pub(crate) reshare_senders: ReShareSenderSet<C>,
+    pub(crate) session_id: Uuid,
+}
+
+impl<C: CurveGroup> ReShareProtocolReceiver<C> {
+    /// Construct a [`ReShareProtocolReceiver`] for a party in the new set of parties with new index `my_idx`.
+    ///
+    /// # Errors
+    /// Returns an error if `my_idx` is zero or larger than the number of parties allowed by the new
+    /// [`Parameters`](crate::keygen::Parameters).
+    pub fn new(
+        my_idx: u16,
+        reshare_senders: ReShareSenderSet<C>,
+        session_id: Uuid,
+    ) -> Result<Self> {
+        if my_idx == 0 {
+            eyre::bail!("party index must be non-zero",);
+        }
+        if my_idx > reshare_senders.new_parameters.number_of_parties {
+            eyre::bail!("provided party index {my_idx} is larger than new parameters allow",);
+        }
+
+        Ok(ReShareProtocolReceiver {
+            my_idx,
+            received_shares: HashMap::new(),
+            reshare_senders,
+            session_id,
+        })
+    }
+
+    /// Add communication received from a party in the old set of parties.
+    ///
+    /// The communication is split into two parts, a part that is broadcast to everyone and a part
+    /// that is specific to each recipient party.
+    /// This uses the information in the [`ReShareSenderSet`] to ensure the received communication is
+    /// consistent with the share of the public key the sender was registered with.
+    ///
+    /// # Errors
+    /// Returns a [`MaliciousPartyError`] identifying the offending party if its broadcast contains
+    /// the wrong number of commitments, either message carries a different session id, the proof of
+    /// knowledge is invalid, the commitment to the constant term does not match the sender's share
+    /// of the public key, or the secret share does not verify against the commitments.
+    /// All other errors indicate an invalid `from` index and are usually the fault of the local
+    /// party.
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "Keeps consistency with the broadcast message, which is consumed"
+    )]
+    pub fn add_old_party_communication(
+        &mut self,
+        from: u16,
+        commitments: BroadcastMessage<C>,
+        share: PartyMessage<C>,
+    ) -> Result<()> {
+        if from == 0 {
+            eyre::bail!("party index must be non-zero",);
+        }
+        if from > self.reshare_senders.old_parameters.number_of_parties {
+            eyre::bail!("party index {from} invalid for old parameters",);
+        }
+
+        if !self.reshare_senders.senders.contains_key(&from) {
+            eyre::bail!("party index {from} is not part of the set of ReShare senders");
+        }
+        if self.received_shares.contains_key(&from) {
+            eyre::bail!("already added message for party {from}");
+        }
+
+        if commitments.commitments.len()
+            != usize::from(self.reshare_senders.new_parameters.threshold)
+        {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+
+        if self.session_id != commitments.session_id {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+        if self.session_id != share.session_id {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+
+        let pk_share = self.reshare_senders.senders[&from];
+
+        // verify ZK proof
+        if !commitments.nizk.verify(from, &pk_share) {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+
+        // Commitment must match the public key share of the sender
+        if commitments.commitments[0] != pk_share {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+
+        if !utils::verify_polynomial_evaluation::<C>(
+            &commitments.commitments.0,
+            self.my_idx,
+            &share.secret_share,
+        ) {
+            eyre::bail!(MaliciousPartyError::new(from as usize));
+        }
+
+        self.received_shares
+            .insert(from, (share.secret_share, commitments.commitments.0));
+
+        Ok(())
+    }
+
+    /// Returns a list of party indices for which we have not yet received and added their communication.
+    pub fn get_missing_parties(&self) -> Vec<u16> {
+        self.reshare_senders
+            .senders
+            .keys()
+            .copied()
+            .filter(|idx| !self.received_shares.contains_key(idx))
+            .collect()
+    }
+
+    /// Indicates if the protocol is ready to advance into the next state.
+    /// See [`ReShareProtocolReceiver::get_missing_parties`] for parties we are still missing information from.
+    pub fn can_advance(&self) -> bool {
+        self.received_shares.len() == self.reshare_senders.senders.len()
+    }
+
+    /// Try to finalize the `ReShare` protocol, putting it in a state where the results of the protocol
+    /// can be obtained.
+    ///
+    /// The resulting [`Finished`] state holds this party's share of the unchanged signing key under
+    /// the new [`Parameters`](crate::keygen::Parameters).
+    ///
+    /// # Errors
+    /// Returns an error if the communication of not all old parties has been added yet, i.e., if
+    /// [`ReShareProtocolReceiver::can_advance`] returns false, or if the constant terms committed to
+    /// by the senders do not recombine to the public key of the [`ReShareSenderSet`].
+    pub fn finalize(self) -> Result<Finished<C>> {
+        if !self.can_advance() {
+            eyre::bail!("cannot finalize, not all messages received");
+        }
+
+        // The Lagrange coefficients are relative to the set of parties that actually took part in
+        // the handover, which is only a threshold sized subset of the old parties.
+        let old_parties = self
+            .reshare_senders
+            .senders
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+        let mut lagrange_coeffs = HashMap::with_capacity(old_parties.len());
+        for party in &old_parties {
+            let lambda =
+                utils::single_lagrange_from_coeff::<C::ScalarField, _>(*party, &old_parties);
+            lagrange_coeffs.insert(party, lambda);
+        }
+
+        let my_secret_key_share = self
+            .received_shares
+            .iter()
+            .fold(C::ScalarField::zero(), |acc, (party, share)| {
+                acc + lagrange_coeffs[party] * share.0
+            });
+        let my_public_key_share = (C::generator() * my_secret_key_share).into_affine();
+
+        let mut public_key_shares = HashMap::new();
+        public_key_shares.insert(self.my_idx, my_public_key_share);
+
+        for party_idx in 1..=self.reshare_senders.new_parameters.number_of_parties {
+            if party_idx == self.my_idx {
+                continue;
+            }
+            let pk_share = self
+                .received_shares
+                .iter()
+                .fold(C::zero(), |acc, (party, (_, com))| {
+                    acc + utils::evaluate_polynomial_in_exponent::<C>(com, party_idx)
+                        * lagrange_coeffs[party]
+                });
+            public_key_shares.insert(party_idx, pk_share.into_affine());
+        }
+
+        let public_key = self
+            .received_shares
+            .iter()
+            .fold(C::zero(), |acc, (party, (_, com))| {
+                acc + com[0] * lagrange_coeffs[party]
+            });
+        let public_key = public_key.into_affine();
+        if public_key != self.reshare_senders.pk {
+            eyre::bail!(
+                "ReShare protocol failed, recombined pk does not match: {:?} != {:?}",
+                public_key,
+                self.reshare_senders.pk
+            );
+        }
+
+        Ok(Finished {
+            my_idx: self.my_idx,
+            session_id: self.session_id,
+            sk_share: my_secret_key_share,
+            pk_shares: public_key_shares,
+            pk: public_key,
+        })
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/reshare/sender.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/sender.rs
@@ -1,0 +1,108 @@
+//! The senders in the `ReShare` protocol.
+//!
+//! A sender is one of the old parties handing the key over. It re-shares its own Shamir share of the
+//! signing key with a fresh polynomial, broadcasts the commitments to that polynomial's
+//! coefficients, and sends its evaluations to the parties in the new set.
+
+use crate::{
+    keygen::schnorr::SchnorrZkProof,
+    reshare::{BroadcastMessage, PartyMessage, sender_set::ReShareSenderSet},
+    shamir::utils,
+};
+use ark_ec::CurveGroup;
+use ark_ff::UniformRand;
+use ark_serialize::CompressedChecked;
+use eyre::Result;
+use rand::{CryptoRng, Rng};
+use uuid::Uuid;
+
+/// The senders in the `ReShare` protocol are the "old" parties, i.e., the set of parties currently holding the shares.
+///
+/// The `ReShare` protocol lets the "old" parties re-share their secret key to a new set of parties (which may be overlapping the current set of parties.)
+pub struct ReShareProtocolSender<C: CurveGroup> {
+    session_id: Uuid,
+    coefficients: Vec<C::ScalarField>,
+    commitments: Vec<C::Affine>,
+    nizk: SchnorrZkProof<C>,
+    reshare_set: ReShareSenderSet<C>,
+}
+
+impl<C: CurveGroup> ReShareProtocolSender<C> {
+    /// Construct a new [`ReShareProtocolSender`] for the old party with index `party_index`.
+    ///
+    /// `my_share` is this party's Shamir share of the signing key as held under the old
+    /// [`Parameters`](crate::keygen::Parameters). Both the old and the new parameters, as well as
+    /// the set of old parties handing the key over, are taken from `reshare_set`.
+    ///
+    /// # Errors
+    /// Returns an error if `party_index` is zero or larger than the number of parties allowed by the
+    /// old [`Parameters`](crate::keygen::Parameters).
+    pub fn new<R: Rng + CryptoRng>(
+        party_index: u16,
+        my_share: &C::ScalarField,
+        reshare_set: ReShareSenderSet<C>,
+        session_id: Uuid,
+        rng: &mut R,
+    ) -> Result<Self> {
+        let old_params = reshare_set.old_parameters;
+        let new_params = reshare_set.new_parameters;
+        if party_index == 0 {
+            eyre::bail!("party index must be non-zero",);
+        }
+        if party_index > old_params.number_of_parties {
+            eyre::bail!("provided party index {party_index} is larger than old parameters allow",);
+        }
+
+        let coefficients = std::iter::once(*my_share)
+            .chain((1..=new_params.degree()).map(|_| C::ScalarField::rand(rng)))
+            .collect::<Vec<_>>();
+
+        let commitments = coefficients
+            .iter()
+            .map(|a_k| (C::generator() * a_k).into_affine())
+            .collect::<Vec<_>>();
+
+        let nizk = SchnorrZkProof::<C>::new(party_index, &coefficients[0], &commitments[0], rng);
+
+        Ok(ReShareProtocolSender {
+            session_id,
+            coefficients,
+            commitments,
+            nizk,
+            reshare_set,
+        })
+    }
+
+    /// Returns the message that must be broadcast to all other participants in this round.
+    pub fn get_broadcast_message(&self) -> BroadcastMessage<C> {
+        BroadcastMessage {
+            session_id: self.session_id,
+            commitments: CompressedChecked(self.commitments.clone()),
+            nizk: self.nizk.clone(),
+        }
+    }
+
+    /// Retrieve the communication for the second round to be sent *privately* to the party with index `for_party` from the new set of parties.
+    ///
+    /// This has to be called for each other party participating in the protocol to retrieve the message intended for this party.
+    /// The message has to be sent using a private communication channel, and should not be available to other parties.
+    ///
+    /// # Errors
+    /// Returns an error if `for_party` is not a valid party index for the new
+    /// [`Parameters`](crate::keygen::Parameters).
+    pub fn get_party_communication(&self, for_party: u16) -> Result<PartyMessage<C>> {
+        if for_party == 0 {
+            eyre::bail!("party index must be non-zero",);
+        }
+        if for_party > self.reshare_set.new_parameters.number_of_parties {
+            eyre::bail!("provided party index {for_party} is larger than new parameters allow",);
+        }
+        let secret_share =
+            utils::evaluate_poly(&self.coefficients, C::ScalarField::from(for_party));
+
+        Ok(PartyMessage {
+            session_id: self.session_id,
+            secret_share,
+        })
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/reshare/sender.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/sender.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use ark_ec::CurveGroup;
 use ark_ff::UniformRand;
-use ark_serialize::CompressedChecked;
 use eyre::Result;
 use rand::{CryptoRng, Rng};
 use std::collections::{BTreeMap, BTreeSet};
@@ -43,6 +42,16 @@ impl<C: CurveGroup> ReShareProtocolSender<C> {
     /// `my_share` is this party's Shamir share of the signing key as held under the old
     /// [`Parameters`](crate::keygen::Parameters). Both the old and the new parameters, as well as
     /// the set of old parties handing the key over, are taken from `reshare_set`.
+    ///
+    /// This function borrows `my_share`; it does not consume, revoke, or erase the old share.
+    /// After a globally agreed successful handover, the application must securely retire old
+    /// shares and prevent honest parties from participating in stale-epoch signing sessions.
+    ///
+    /// `session_id` must be the same for every participant *and* globally unique per run. It is the
+    /// only run-specific input to the proof-of-possession context, so reusing it with the same
+    /// parameters makes this broadcast replayable into a later run, where the sender's fresh
+    /// evaluations fail against the stale commitments and the honest sender is blamed. Use a fresh
+    /// [`Uuid::new_v4`] per run.
     ///
     /// # Errors
     /// Returns an error if `party_index` is zero or larger than the number of parties allowed by the
@@ -108,7 +117,7 @@ impl<C: CurveGroup> ReShareProtocolSender<C> {
     pub fn get_broadcast_message(&self) -> BroadcastMessage<C> {
         BroadcastMessage {
             session_id: self.session_id,
-            commitments: CompressedChecked(self.commitments.clone()),
+            commitments: self.commitments.clone(),
             nizk: self.nizk.clone(),
         }
     }
@@ -191,7 +200,7 @@ impl<C: CurveGroup> ReShareProtocolSender<C> {
     /// Ignore a new party that missed the externally agreed verdict deadline.
     ///
     /// Every honest participant must apply the identical exclusion set, matching
-    /// [`ReShareBlameRound::disqualify_missing_verdict`](crate::reshare::blame::ReShareBlameRound::disqualify_missing_verdict).
+    /// [`ReShareBlameRound::exclude_missing_verdict`](crate::reshare::blame::ReShareBlameRound::exclude_missing_verdict).
     /// A sender that applies a different set derives a different accuser set and is disqualified by
     /// the receivers for an inconsistent revelation.
     ///

--- a/threshold-eddsa-babyjubjub/src/reshare/sender.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/sender.rs
@@ -7,6 +7,7 @@
 use crate::{
     keygen::{
         SecretScalars,
+        blame::{BlameRevelation, RevealedShare},
         schnorr::{self, SchnorrZkProof},
     },
     reshare::{BroadcastMessage, PartyMessage, sender_set::ReShareSenderSet},
@@ -17,6 +18,7 @@ use ark_ff::UniformRand;
 use ark_serialize::CompressedChecked;
 use eyre::Result;
 use rand::{CryptoRng, Rng};
+use std::collections::BTreeSet;
 use uuid::Uuid;
 
 /// The senders in the `ReShare` protocol are the "old" parties, i.e., the set of parties currently holding the shares.
@@ -126,6 +128,30 @@ impl<C: CurveGroup> ReShareProtocolSender<C> {
         Ok(PartyMessage {
             session_id: self.session_id,
             secret_share,
+        })
+    }
+
+    /// Reveal the committed polynomial evaluation for every new party that accused this sender.
+    ///
+    /// # Errors
+    /// Returns an error if the accuser set is empty or contains an invalid new-party identifier.
+    pub fn get_blame_revelation(&self, accusers: &BTreeSet<u16>) -> Result<BlameRevelation<C>> {
+        if accusers.is_empty() {
+            eyre::bail!("cannot create a blame revelation without an accuser");
+        }
+        let mut shares = Vec::with_capacity(accusers.len());
+        for receiver in accusers {
+            if *receiver == 0 || *receiver > self.reshare_set.new_parameters.number_of_parties {
+                eyre::bail!("new party index {receiver} is invalid");
+            }
+            shares.push(RevealedShare {
+                receiver: *receiver,
+                share: utils::evaluate_poly(&self.coefficients, C::ScalarField::from(*receiver)),
+            });
+        }
+        Ok(BlameRevelation {
+            session_id: self.session_id,
+            shares,
         })
     }
 }

--- a/threshold-eddsa-babyjubjub/src/reshare/sender.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/sender.rs
@@ -5,7 +5,10 @@
 //! coefficients, and sends its evaluations to the parties in the new set.
 
 use crate::{
-    keygen::schnorr::SchnorrZkProof,
+    keygen::{
+        SecretScalars,
+        schnorr::{self, SchnorrZkProof},
+    },
     reshare::{BroadcastMessage, PartyMessage, sender_set::ReShareSenderSet},
     shamir::utils,
 };
@@ -21,13 +24,15 @@ use uuid::Uuid;
 /// The `ReShare` protocol lets the "old" parties re-share their secret key to a new set of parties (which may be overlapping the current set of parties.)
 pub struct ReShareProtocolSender<C: CurveGroup> {
     session_id: Uuid,
-    coefficients: Vec<C::ScalarField>,
+    coefficients: SecretScalars<C::ScalarField>,
     commitments: Vec<C::Affine>,
     nizk: SchnorrZkProof<C>,
     reshare_set: ReShareSenderSet<C>,
 }
 
 impl<C: CurveGroup> ReShareProtocolSender<C> {
+    pub(super) const CONTEXT_DOMAIN: &'static [u8] = b"PEDPOP_RESHARE_V1";
+
     /// Construct a new [`ReShareProtocolSender`] for the old party with index `party_index`.
     ///
     /// `my_share` is this party's Shamir share of the signing key as held under the old
@@ -52,17 +57,35 @@ impl<C: CurveGroup> ReShareProtocolSender<C> {
         if party_index > old_params.number_of_parties {
             eyre::bail!("provided party index {party_index} is larger than old parameters allow",);
         }
+        reshare_set.correct()?;
+        let Some(expected_public_share) = reshare_set.senders.get(&party_index) else {
+            eyre::bail!("party index {party_index} is not a selected reshare sender");
+        };
+        if (C::generator() * my_share).into_affine() != *expected_public_share {
+            eyre::bail!("secret share does not match party {party_index}'s public share");
+        }
 
-        let coefficients = std::iter::once(*my_share)
-            .chain((1..=new_params.degree()).map(|_| C::ScalarField::rand(rng)))
-            .collect::<Vec<_>>();
+        let coefficients = SecretScalars(
+            std::iter::once(*my_share)
+                .chain((1..=new_params.degree()).map(|_| C::ScalarField::rand(rng)))
+                .collect::<Vec<_>>(),
+        );
 
         let commitments = coefficients
             .iter()
             .map(|a_k| (C::generator() * a_k).into_affine())
             .collect::<Vec<_>>();
 
-        let nizk = SchnorrZkProof::<C>::new(party_index, &coefficients[0], &commitments[0], rng);
+        let context =
+            schnorr::proof_context(Self::CONTEXT_DOMAIN, session_id, &[old_params, new_params]);
+        let nizk = SchnorrZkProof::<C>::new(
+            &context,
+            party_index,
+            &coefficients[0],
+            &commitments[0],
+            &commitments[1..],
+            rng,
+        );
 
         Ok(ReShareProtocolSender {
             session_id,

--- a/threshold-eddsa-babyjubjub/src/reshare/sender.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/sender.rs
@@ -7,7 +7,7 @@
 use crate::{
     keygen::{
         SecretScalars,
-        blame::{BlameRevelation, RevealedShare},
+        blame::{BlameRevelation, BlameVerdict, RevealedShare},
         schnorr::{self, SchnorrZkProof},
     },
     reshare::{BroadcastMessage, PartyMessage, sender_set::ReShareSenderSet},
@@ -18,7 +18,7 @@ use ark_ff::UniformRand;
 use ark_serialize::CompressedChecked;
 use eyre::Result;
 use rand::{CryptoRng, Rng};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use uuid::Uuid;
 
 /// The senders in the `ReShare` protocol are the "old" parties, i.e., the set of parties currently holding the shares.
@@ -26,10 +26,13 @@ use uuid::Uuid;
 /// The `ReShare` protocol lets the "old" parties re-share their secret key to a new set of parties (which may be overlapping the current set of parties.)
 pub struct ReShareProtocolSender<C: CurveGroup> {
     session_id: Uuid,
+    my_idx: u16,
     coefficients: SecretScalars<C::ScalarField>,
     commitments: Vec<C::Affine>,
     nizk: SchnorrZkProof<C>,
     reshare_set: ReShareSenderSet<C>,
+    verdicts: BTreeMap<u16, BlameVerdict>,
+    excluded_verdict_parties: BTreeSet<u16>,
 }
 
 impl<C: CurveGroup> ReShareProtocolSender<C> {
@@ -91,10 +94,13 @@ impl<C: CurveGroup> ReShareProtocolSender<C> {
 
         Ok(ReShareProtocolSender {
             session_id,
+            my_idx: party_index,
             coefficients,
             commitments,
             nizk,
             reshare_set,
+            verdicts: BTreeMap::new(),
+            excluded_verdict_parties: BTreeSet::new(),
         })
     }
 
@@ -131,27 +137,137 @@ impl<C: CurveGroup> ReShareProtocolSender<C> {
         })
     }
 
-    /// Reveal the committed polynomial evaluation for every new party that accused this sender.
+    /// Add a new party's blame verdict broadcast.
+    ///
+    /// The sender derives the set of accusers it must answer from these verdicts, so they require
+    /// the same reliable broadcast and sender authentication as on the receiver side. Bind the
+    /// externally authenticated identity to `from`.
     ///
     /// # Errors
-    /// Returns an error if the accuser set is empty or contains an invalid new-party identifier.
-    pub fn get_blame_revelation(&self, accusers: &BTreeSet<u16>) -> Result<BlameRevelation<C>> {
-        if accusers.is_empty() {
-            eyre::bail!("cannot create a blame revelation without an accuser");
+    /// Returns an error for an invalid, duplicate, or already-excluded new party, a session
+    /// mismatch, or a verdict blaming an old party outside the selected sender set.
+    pub fn add_verdict(&mut self, from: u16, verdict: BlameVerdict) -> Result<()> {
+        if from == 0 {
+            eyre::bail!("party index must be non-zero",);
         }
-        let mut shares = Vec::with_capacity(accusers.len());
-        for receiver in accusers {
-            if *receiver == 0 || *receiver > self.reshare_set.new_parameters.number_of_parties {
-                eyre::bail!("new party index {receiver} is invalid");
-            }
-            shares.push(RevealedShare {
+        if from > self.reshare_set.new_parameters.number_of_parties {
+            eyre::bail!("new party index {from} invalid for the new parameters");
+        }
+        if self.excluded_verdict_parties.contains(&from) {
+            eyre::bail!("new party {from}'s verdict was already excluded");
+        }
+        if self.verdicts.contains_key(&from) {
+            eyre::bail!("already added verdict from new party {from}");
+        }
+        if verdict.session_id != self.session_id {
+            eyre::bail!("session id mismatch in verdict from new party {from}");
+        }
+        if verdict
+            .blamed_parties
+            .iter()
+            .any(|sender| !self.reshare_set.senders.contains_key(sender))
+        {
+            eyre::bail!("verdict from new party {from} blames an unselected old sender");
+        }
+        self.verdicts.insert(from, verdict);
+        Ok(())
+    }
+
+    /// New parties whose verdict broadcast is still missing.
+    #[must_use]
+    pub fn missing_verdicts(&self) -> Vec<u16> {
+        (1..=self.reshare_set.new_parameters.number_of_parties)
+            .filter(|party| !self.verdicts.contains_key(party))
+            .filter(|party| !self.excluded_verdict_parties.contains(party))
+            .collect()
+    }
+
+    /// Whether every new party's verdict has been received or externally excluded.
+    #[must_use]
+    pub fn verdicts_complete(&self) -> bool {
+        self.missing_verdicts().is_empty()
+    }
+
+    /// Ignore a new party that missed the externally agreed verdict deadline.
+    ///
+    /// Every honest participant must apply the identical exclusion set, matching
+    /// [`ReShareBlameRound::disqualify_missing_verdict`](crate::reshare::blame::ReShareBlameRound::disqualify_missing_verdict).
+    /// A sender that applies a different set derives a different accuser set and is disqualified by
+    /// the receivers for an inconsistent revelation.
+    ///
+    /// # Errors
+    /// Returns an error for an invalid new party, one whose verdict was already accepted or
+    /// excluded, or if the exclusion would leave fewer than the new threshold of receivers.
+    pub fn exclude_missing_verdict(&mut self, party: u16) -> Result<()> {
+        if party == 0 || party > self.reshare_set.new_parameters.number_of_parties {
+            eyre::bail!("new party index {party} invalid for the new parameters");
+        }
+        if self.verdicts.contains_key(&party) {
+            eyre::bail!("new party {party}'s verdict was already accepted");
+        }
+        if self.excluded_verdict_parties.contains(&party) {
+            eyre::bail!("new party {party}'s verdict was already excluded");
+        }
+        let remaining = usize::from(self.reshare_set.new_parameters.number_of_parties)
+            - self.excluded_verdict_parties.len()
+            - 1;
+        if remaining < usize::from(self.reshare_set.new_parameters.threshold) {
+            eyre::bail!("verdict exclusion would leave fewer than the threshold receivers");
+        }
+        self.excluded_verdict_parties.insert(party);
+        Ok(())
+    }
+
+    /// Reveal the committed polynomial evaluation for every new party that accused this sender.
+    ///
+    /// The accuser set is derived from the verdicts collected with
+    /// [`ReShareProtocolSender::add_verdict`] and is never supplied by the caller: an accuser that
+    /// did not broadcast a blaming verdict is never answered. Returns `None` when no new party
+    /// accused this sender.
+    ///
+    /// The constant term of the resharing polynomial is this sender's secret key share, so
+    /// revealing `new_parameters.threshold` evaluations would let any observer interpolate it. At
+    /// that point the sender refuses: either it really is malicious and being disqualified is the
+    /// correct outcome, or the accusers form a threshold-sized coalition that can already
+    /// reconstruct the key from their own new shares. Disqualification is never worse than
+    /// disclosure.
+    ///
+    /// # Errors
+    /// Returns an error until every new party's verdict has been received or externally excluded,
+    /// or if answering the accusers would disclose the secret key share.
+    pub fn get_blame_revelation(&self) -> Result<Option<BlameRevelation<C>>> {
+        if !self.verdicts_complete() {
+            eyre::bail!("cannot reveal before every new party's verdict is received or excluded");
+        }
+        let accusers = self
+            .verdicts
+            .iter()
+            .filter(|(_, verdict)| verdict.blamed_parties.contains(&self.my_idx))
+            .map(|(accuser, _)| *accuser)
+            .collect::<BTreeSet<_>>();
+        if accusers.is_empty() {
+            return Ok(None);
+        }
+        let threshold = usize::from(self.reshare_set.new_parameters.threshold);
+        if accusers.len() >= threshold {
+            eyre::bail!(
+                "refusing to reveal {} evaluations of a degree-{} polynomial: at the new threshold \
+                 of {threshold} this would disclose party {}'s secret key share",
+                accusers.len(),
+                self.reshare_set.new_parameters.degree(),
+                self.my_idx,
+            );
+        }
+        let shares = accusers
+            .iter()
+            .map(|receiver| RevealedShare {
                 receiver: *receiver,
                 share: utils::evaluate_poly(&self.coefficients, C::ScalarField::from(*receiver)),
-            });
-        }
-        Ok(BlameRevelation {
+            })
+            .collect();
+        Ok(Some(BlameRevelation {
             session_id: self.session_id,
             shares,
-        })
+        }))
     }
 }

--- a/threshold-eddsa-babyjubjub/src/reshare/sender_set.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/sender_set.rs
@@ -6,6 +6,7 @@
 
 use crate::{keygen::Parameters, shamir::utils};
 use ark_ec::CurveGroup;
+use ark_serialize::Valid;
 use std::collections::BTreeMap;
 
 /// A struct representing the parties (and their public information) participating in a `ReShare` protocol run.
@@ -45,6 +46,12 @@ impl<C: CurveGroup> ReShareSenderSet<C> {
     /// Returns an error if the set of senders is already complete, i.e., if [`ReShareSenderSet::ready`]
     /// returns true, or if a party with the same `id` has been added before.
     pub fn add_party(&mut self, id: u16, pk_share: C::Affine) -> eyre::Result<()> {
+        if id == 0 || id > self.old_parameters.number_of_parties {
+            return Err(eyre::eyre!("Party id {id} is outside the old party set"));
+        }
+        if pk_share.check().is_err() {
+            return Err(eyre::eyre!("Public-key share for party {id} is invalid"));
+        }
         if self.ready() {
             return Err(eyre::eyre!(
                 "Cannot add party {} to ReShareSenderSet, already have enough parties",

--- a/threshold-eddsa-babyjubjub/src/reshare/sender_set.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/sender_set.rs
@@ -1,8 +1,7 @@
 //! The set of old parties handing a key over in the `ReShare` protocol.
 //!
-//! This module defines the `ReShareSenderSet` struct, which pins down the threshold sized subset of
-//! the old parties taking part in the handover together with their shares of the public key, so that
-//! the receivers can check the communication they get from them.
+//! This module defines the `ReShareSenderSet` struct, which pins down a threshold-or-larger subset
+//! of the old parties taking part in the handover together with their public-key shares.
 
 use crate::{keygen::Parameters, shamir::utils};
 use ark_ec::CurveGroup;
@@ -35,28 +34,21 @@ impl<C: CurveGroup> ReShareSenderSet<C> {
         }
     }
 
-    /// Check if the set of parties is ready, i.e., if enough parties have been added to the set
+    /// Check if at least the old threshold number of parties have been added.
     pub fn ready(&self) -> bool {
-        self.senders.len() == usize::from(self.old_parameters.threshold)
+        self.senders.len() >= usize::from(self.old_parameters.threshold)
     }
 
     /// Adds a party to the set of `ReShare` senders. A party's public information is made up of its share of the public key
     ///
     /// # Errors
-    /// Returns an error if the set of senders is already complete, i.e., if [`ReShareSenderSet::ready`]
-    /// returns true, or if a party with the same `id` has been added before.
+    /// Returns an error if a party with the same `id` has been added before.
     pub fn add_party(&mut self, id: u16, pk_share: C::Affine) -> eyre::Result<()> {
         if id == 0 || id > self.old_parameters.number_of_parties {
             return Err(eyre::eyre!("Party id {id} is outside the old party set"));
         }
         if pk_share.check().is_err() {
             return Err(eyre::eyre!("Public-key share for party {id} is invalid"));
-        }
-        if self.ready() {
-            return Err(eyre::eyre!(
-                "Cannot add party {} to ReShareSenderSet, already have enough parties",
-                id
-            ));
         }
 
         if self.senders.contains_key(&id) {

--- a/threshold-eddsa-babyjubjub/src/reshare/sender_set.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/sender_set.rs
@@ -1,0 +1,87 @@
+//! The set of old parties handing a key over in the `ReShare` protocol.
+//!
+//! This module defines the `ReShareSenderSet` struct, which pins down the threshold sized subset of
+//! the old parties taking part in the handover together with their shares of the public key, so that
+//! the receivers can check the communication they get from them.
+
+use crate::{keygen::Parameters, shamir::utils};
+use ark_ec::CurveGroup;
+use std::collections::BTreeMap;
+
+/// A struct representing the parties (and their public information) participating in a `ReShare` protocol run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReShareSenderSet<C: CurveGroup> {
+    // BTreeMap to always have the same order when iterating
+    // this holds pk_share points, already deserialized
+    pub(crate) senders: BTreeMap<u16, C::Affine>,
+    pub(crate) pk: C::Affine,
+    pub(crate) old_parameters: Parameters,
+    pub(crate) new_parameters: Parameters,
+}
+
+impl<C: CurveGroup> ReShareSenderSet<C> {
+    /// Start the construction of a new [`ReShareSenderSet`].
+    pub fn for_pk_and_parameters(
+        pk: C::Affine,
+        old_parameters: Parameters,
+        new_parameters: Parameters,
+    ) -> ReShareSenderSet<C> {
+        ReShareSenderSet {
+            senders: BTreeMap::default(),
+            pk,
+            old_parameters,
+            new_parameters,
+        }
+    }
+
+    /// Check if the set of parties is ready, i.e., if enough parties have been added to the set
+    pub fn ready(&self) -> bool {
+        self.senders.len() == usize::from(self.old_parameters.threshold)
+    }
+
+    /// Adds a party to the set of `ReShare` senders. A party's public information is made up of its share of the public key
+    ///
+    /// # Errors
+    /// Returns an error if the set of senders is already complete, i.e., if [`ReShareSenderSet::ready`]
+    /// returns true, or if a party with the same `id` has been added before.
+    pub fn add_party(&mut self, id: u16, pk_share: C::Affine) -> eyre::Result<()> {
+        if self.ready() {
+            return Err(eyre::eyre!(
+                "Cannot add party {} to ReShareSenderSet, already have enough parties",
+                id
+            ));
+        }
+
+        if self.senders.contains_key(&id) {
+            return Err(eyre::eyre!("Duplicate party id: {}", id));
+        }
+        self.senders.insert(id, pk_share);
+        Ok(())
+    }
+
+    /// Check if the set of parties is correct, i.e., if the shares can be recombined to the public key
+    ///
+    /// # Errors
+    /// Returns an error if the set of senders is not complete yet, i.e., if
+    /// [`ReShareSenderSet::ready`] returns false, or if the shares of the senders do not recombine to
+    /// the public key of this set.
+    pub fn correct(&self) -> eyre::Result<()> {
+        if !self.ready() {
+            eyre::bail!("Cannot check correctness of ReShareSenderSet, not enough parties");
+        }
+
+        let indices: Vec<_> = self.senders.keys().copied().collect();
+        let recomb_pk = self.senders.iter().fold(C::zero(), |acc, (&idx, p)| {
+            acc + *p * utils::single_lagrange_from_coeff::<C::ScalarField, u16>(idx, &indices)
+        });
+
+        if recomb_pk.into_affine() != self.pk {
+            eyre::bail!(
+                "ReShareSenderSet is not correct, recombined pk does not match: {:?} != {:?}",
+                recomb_pk.into_affine(),
+                self.pk
+            );
+        }
+        Ok(())
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/reshare/sender_set.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/sender_set.rs
@@ -21,6 +21,13 @@ pub struct ReShareSenderSet<C: CurveGroup> {
 
 impl<C: CurveGroup> ReShareSenderSet<C> {
     /// Start the construction of a new [`ReShareSenderSet`].
+    ///
+    /// `pk` is stored as given; unlike the per-party shares in [`ReShareSenderSet::add_party`], it is
+    /// not checked to be a non-zero point in the prime-order subgroup. A degenerate `pk` with
+    /// matching shares therefore passes [`ReShareSenderSet::correct`] and reaches
+    /// [`Finished::pk`](crate::keygen::finished::Finished::pk); it is rejected later, by
+    /// [`DLogShareShamir::new`](crate::shamir::secret::DLogShareShamir::new). Supply `pk` from
+    /// authenticated DKG or reshare output.
     pub fn for_pk_and_parameters(
         pk: C::Affine,
         old_parameters: Parameters,

--- a/threshold-eddsa-babyjubjub/src/reshare/test.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/test.rs
@@ -102,7 +102,7 @@ fn run_reshare<R: Rng + CryptoRng>(
                     .add_old_party_communication(
                         from,
                         broadcasts[position].clone(),
-                        communications[position][party_position(my_idx)].clone(),
+                        &communications[position][party_position(my_idx)],
                     )
                     .expect("secret share of an honest sender verifies against its commitments");
             }
@@ -269,7 +269,16 @@ fn sign<R: Rng + CryptoRng>(
 
     let x_shares = parties
         .iter()
-        .map(|party| DLogShareShamir(party.sk_share))
+        .enumerate()
+        .map(|(position, party)| {
+            DLogShareShamir::new(
+                party.sk_share,
+                party_id(position),
+                params.number_of_parties,
+                params.threshold,
+            )
+            .expect("valid reshared signing share metadata")
+        })
         .collect::<Vec<_>>();
     let public_key_shares = (1..=params.number_of_parties)
         .map(|party_id| parties[0].pk_shares[&party_id])
@@ -396,6 +405,9 @@ enum ReShareBlameTestMode {
     Valid,
     Malformed,
     Missing,
+    MissingPrivateMessage,
+    MissingBroadcast,
+    MissingVerdict,
 }
 
 #[allow(
@@ -460,19 +472,39 @@ fn run_reshare_blame_test(
         .collect::<Vec<_>>();
 
     // Dealer 1 equivocates only toward receiver 2, which will complain publicly.
-    private_shares[0][1].secret_share += ScalarField::one();
+    if !matches!(
+        mode,
+        ReShareBlameTestMode::MissingPrivateMessage | ReShareBlameTestMode::MissingBroadcast
+    ) {
+        private_shares[0][1].secret_share += ScalarField::one();
+    }
     let mut receivers = (1..=new_params.number_of_parties)
         .map(|receiver| {
             let mut state = ReShareProtocolReceiver::new(receiver, sender_set.clone(), session_id)
                 .expect("valid new receiver");
             for sender in 1..=old_params.number_of_parties {
-                state
-                    .add_old_party_communication_for_blame(
-                        sender,
-                        broadcasts[party_position(sender)].clone(),
-                        private_shares[party_position(sender)][party_position(receiver)].clone(),
-                    )
-                    .expect("sender communication retained for blame");
+                if mode == ReShareBlameTestMode::MissingBroadcast
+                    && sender == old_params.number_of_parties
+                {
+                    state
+                        .disqualify_missing_sender(sender)
+                        .expect("common timeout disqualifies missing sender broadcast");
+                } else if mode == ReShareBlameTestMode::MissingPrivateMessage
+                    && receiver == 2
+                    && sender == 1
+                {
+                    state
+                        .complain_missing_share(1, broadcasts[0].clone())
+                        .expect("missing private reshare evaluation becomes a complaint");
+                } else {
+                    state
+                        .add_old_party_communication_for_blame(
+                            sender,
+                            broadcasts[party_position(sender)].clone(),
+                            &private_shares[party_position(sender)][party_position(receiver)],
+                        )
+                        .expect("sender communication retained for blame");
+                }
             }
             state.blame_round().expect("all sender messages received")
         })
@@ -482,31 +514,52 @@ fn run_reshare_blame_test(
         .map(crate::reshare::blame::ReShareBlameRound::verdict)
         .collect::<Vec<_>>();
     assert!(verdicts[0].is_ok());
+    let expected_blame = if mode == ReShareBlameTestMode::MissingBroadcast {
+        vec![]
+    } else {
+        vec![1]
+    };
     assert_eq!(
         verdicts[1]
             .blamed_parties()
             .iter()
             .copied()
             .collect::<Vec<_>>(),
-        vec![1]
+        expected_blame,
     );
-    for (receiver, state) in receivers.iter_mut().enumerate() {
+    let completing_receivers = if mode == ReShareBlameTestMode::MissingVerdict {
+        receivers.len() - 1
+    } else {
+        receivers.len()
+    };
+    for (receiver, state) in receivers.iter_mut().take(completing_receivers).enumerate() {
         for (sender, verdict) in verdicts.iter().enumerate() {
-            if receiver != sender {
+            if receiver != sender
+                && !(mode == ReShareBlameTestMode::MissingVerdict
+                    && sender + 1 == usize::from(new_params.number_of_parties))
+            {
                 state
                     .add_verdict(party_id(sender), verdict.clone())
                     .expect("valid new-party verdict");
             }
         }
+        if mode == ReShareBlameTestMode::MissingVerdict {
+            state
+                .exclude_missing_verdict(new_params.number_of_parties)
+                .expect("common timeout excludes the missing receiver verdict");
+        }
     }
 
-    let accusers = receivers[0].accusations().expect("all verdicts received")[&1].clone();
-    let mut revelation = if mode == ReShareBlameTestMode::Missing {
+    let accusers = receivers[0].accusations().expect("all verdicts received");
+    let mut revelation = if matches!(
+        mode,
+        ReShareBlameTestMode::Missing | ReShareBlameTestMode::MissingBroadcast
+    ) {
         None
     } else {
         Some(
             sender_states[0]
-                .get_blame_revelation(&accusers)
+                .get_blame_revelation(&accusers[&1])
                 .expect("accused sender reveals committed shares"),
         )
     };
@@ -517,12 +570,12 @@ fn run_reshare_blame_test(
             .shares[0]
             .share += ScalarField::one();
     }
-    for state in &mut receivers {
+    for state in receivers.iter_mut().take(completing_receivers) {
         if let Some(revelation) = &revelation {
             state
                 .add_revelation(1, revelation)
                 .expect("old-sender revelation processed");
-        } else {
+        } else if mode == ReShareBlameTestMode::Missing {
             state
                 .disqualify_missing_sender(1)
                 .expect("missing old sender disqualified");
@@ -531,15 +584,29 @@ fn run_reshare_blame_test(
 
     let results = receivers
         .into_iter()
+        .take(completing_receivers)
         .map(|state| state.finalize().expect("enough qualified senders survive"))
         .collect::<Vec<_>>();
-    let expected_disqualified = if mode == ReShareBlameTestMode::Valid {
+    let expected_disqualified = if mode == ReShareBlameTestMode::MissingBroadcast {
+        vec![old_params.number_of_parties]
+    } else if matches!(
+        mode,
+        ReShareBlameTestMode::Valid
+            | ReShareBlameTestMode::MissingPrivateMessage
+            | ReShareBlameTestMode::MissingVerdict
+    ) {
         vec![]
     } else {
         vec![1]
     };
     for result in &results {
         assert_eq!(result.disqualified_parties, expected_disqualified);
+        let expected_excluded = if mode == ReShareBlameTestMode::MissingVerdict {
+            vec![new_params.number_of_parties]
+        } else {
+            vec![]
+        };
+        assert_eq!(result.excluded_verdict_parties, expected_excluded);
         assert_eq!(result.finished.pk, old_parties[0].pk);
         assert_eq!(result.finished.pk_shares, results[0].finished.pk_shares);
         assert_eq!(
@@ -571,6 +638,33 @@ fn reshare_blame_disqualifies_malformed_sender_revelation() {
 fn reshare_blame_disqualifies_missing_sender_revelation() {
     run_reshare_blame_test(
         ReShareBlameTestMode::Missing,
+        Parameters::new(4, 2),
+        Parameters::new(3, 2),
+    );
+}
+
+#[test]
+fn reshare_blame_recovers_a_missing_private_message() {
+    run_reshare_blame_test(
+        ReShareBlameTestMode::MissingPrivateMessage,
+        Parameters::new(4, 2),
+        Parameters::new(3, 2),
+    );
+}
+
+#[test]
+fn reshare_continues_after_a_missing_sender_broadcast() {
+    run_reshare_blame_test(
+        ReShareBlameTestMode::MissingBroadcast,
+        Parameters::new(4, 2),
+        Parameters::new(3, 2),
+    );
+}
+
+#[test]
+fn reshare_blame_continues_after_a_missing_receiver_verdict() {
+    run_reshare_blame_test(
+        ReShareBlameTestMode::MissingVerdict,
         Parameters::new(4, 2),
         Parameters::new(3, 2),
     );

--- a/threshold-eddsa-babyjubjub/src/reshare/test.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/test.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     Affine, BaseField, Curve, ScalarField,
-    keygen::{Parameters, finished::Finished, test::run_keygen},
+    keygen::{Parameters, blame::BlameVerdict, finished::Finished, test::run_keygen},
     reshare::{
         receiver::ReShareProtocolReceiver, sender::ReShareProtocolSender,
         sender_set::ReShareSenderSet,
@@ -273,6 +273,7 @@ fn sign<R: Rng + CryptoRng>(
         .map(|(position, party)| {
             DLogShareShamir::new(
                 party.sk_share,
+                &public_key,
                 party_id(position),
                 params.number_of_parties,
                 params.threshold,
@@ -442,7 +443,7 @@ fn run_reshare_blame_test(
         .correct()
         .expect("all old shares reconstruct the key");
 
-    let sender_states = (1..=old_params.number_of_parties)
+    let mut sender_states = (1..=old_params.number_of_parties)
         .map(|sender| {
             ReShareProtocolSender::<Curve>::new(
                 sender,
@@ -550,18 +551,32 @@ fn run_reshare_blame_test(
         }
     }
 
-    let accusers = receivers[0].accusations().expect("all verdicts received");
+    // The accused old sender collects the same verdict broadcasts the receivers saw and derives its
+    // own accuser set from them. It is never handed one.
+    for (position, verdict) in verdicts.iter().enumerate() {
+        if mode == ReShareBlameTestMode::MissingVerdict
+            && position + 1 == usize::from(new_params.number_of_parties)
+        {
+            continue;
+        }
+        sender_states[0]
+            .add_verdict(party_id(position), verdict.clone())
+            .expect("valid new-party verdict");
+    }
+    if mode == ReShareBlameTestMode::MissingVerdict {
+        sender_states[0]
+            .exclude_missing_verdict(new_params.number_of_parties)
+            .expect("common timeout excludes the missing receiver verdict");
+    }
     let mut revelation = if matches!(
         mode,
         ReShareBlameTestMode::Missing | ReShareBlameTestMode::MissingBroadcast
     ) {
         None
     } else {
-        Some(
-            sender_states[0]
-                .get_blame_revelation(&accusers[&1])
-                .expect("accused sender reveals committed shares"),
-        )
+        sender_states[0]
+            .get_blame_revelation()
+            .expect("accused sender reveals committed shares")
     };
     if mode == ReShareBlameTestMode::Malformed {
         revelation
@@ -667,5 +682,162 @@ fn reshare_blame_continues_after_a_missing_receiver_verdict() {
         ReShareBlameTestMode::MissingVerdict,
         Parameters::new(4, 2),
         Parameters::new(3, 2),
+    );
+}
+
+/// Fixture for the reshare revelation tests: a 4-party old committee that has agreed to hand its key
+/// over to `new_params`, from which fresh states for accused old sender 1 can be built.
+struct BlameSenderFixture {
+    old_parties: Vec<Finished<Curve>>,
+    sender_set: ReShareSenderSet<Curve>,
+    session_id: Uuid,
+    new_params: Parameters,
+}
+
+impl BlameSenderFixture {
+    fn new<R: Rng + CryptoRng>(rng: &mut R) -> Self {
+        let old_params = Parameters::new(4, 2);
+        let new_params = Parameters::new(3, 2);
+        let old_parties = run_keygen(
+            old_params.number_of_parties,
+            old_params.threshold,
+            Uuid::new_v4(),
+            rng,
+        );
+        let mut sender_set = ReShareSenderSet::<Curve>::for_pk_and_parameters(
+            old_parties[0].pk,
+            old_params,
+            new_params,
+        );
+        for sender in 1..=old_params.number_of_parties {
+            sender_set
+                .add_party(
+                    sender,
+                    old_parties[party_position(sender)].pk_shares[&sender],
+                )
+                .expect("honest old public-key share");
+        }
+        Self {
+            old_parties,
+            sender_set,
+            session_id: Uuid::new_v4(),
+            new_params,
+        }
+    }
+
+    /// A fresh state for old sender 1, the sender the tests accuse.
+    fn accused_sender<R: Rng + CryptoRng>(&self, rng: &mut R) -> ReShareProtocolSender<Curve> {
+        ReShareProtocolSender::<Curve>::new(
+            1,
+            &self.old_parties[0].sk_share,
+            self.sender_set.clone(),
+            self.session_id,
+            rng,
+        )
+        .expect("valid old sender")
+    }
+
+    fn verdict(&self, blamed: &[u16]) -> BlameVerdict {
+        BlameVerdict {
+            session_id: self.session_id,
+            blamed_parties: blamed.iter().copied().collect(),
+        }
+    }
+}
+
+/// The accuser set is derived from collected verdicts, so nothing is revealed until every new party's
+/// verdict has arrived or been excluded.
+#[test]
+fn reshare_sender_reveals_nothing_before_verdicts_complete() {
+    let mut rng = rand::thread_rng();
+    let fixture = BlameSenderFixture::new(&mut rng);
+    let mut sender = fixture.accused_sender(&mut rng);
+
+    assert!(
+        sender.get_blame_revelation().is_err(),
+        "must not reveal before every verdict is in"
+    );
+    sender
+        .add_verdict(1, fixture.verdict(&[1]))
+        .expect("accusing verdict");
+    assert!(
+        sender.get_blame_revelation().is_err(),
+        "two new-party verdicts are still missing"
+    );
+}
+
+/// Only a new party that actually broadcast a blaming verdict is answered. A caller cannot name an
+/// accuser, so a party that did not complain never receives an evaluation.
+#[test]
+fn reshare_sender_answers_only_real_accusers() {
+    let mut rng = rand::thread_rng();
+    let fixture = BlameSenderFixture::new(&mut rng);
+
+    // Every new party complains about a different old sender, so sender 1 has nothing to answer.
+    let mut unaccused = fixture.accused_sender(&mut rng);
+    for new_party in 1..=fixture.new_params.number_of_parties {
+        unaccused
+            .add_verdict(new_party, fixture.verdict(&[2]))
+            .expect("valid new-party verdict");
+    }
+    assert!(
+        unaccused
+            .get_blame_revelation()
+            .expect("verdicts are complete")
+            .is_none(),
+        "a sender nobody accused reveals nothing"
+    );
+
+    // Only new party 2 accuses sender 1, so only new party 2 is answered.
+    let mut sender = fixture.accused_sender(&mut rng);
+    sender
+        .add_verdict(1, fixture.verdict(&[]))
+        .expect("ok verdict");
+    sender
+        .add_verdict(2, fixture.verdict(&[1]))
+        .expect("accusing verdict");
+    sender
+        .add_verdict(3, fixture.verdict(&[]))
+        .expect("ok verdict");
+    let revelation = sender
+        .get_blame_revelation()
+        .expect("verdicts are complete")
+        .expect("the sender was accused");
+    assert_eq!(
+        revelation
+            .shares
+            .iter()
+            .map(|share| share.receiver)
+            .collect::<Vec<_>>(),
+        vec![2],
+        "only the accuser is answered"
+    );
+}
+
+/// The constant term of the resharing polynomial is the sender's secret key share, so answering
+/// `new_threshold` accusers would publish enough evaluations to interpolate it. The sender refuses
+/// and accepts disqualification instead.
+#[test]
+fn reshare_sender_refuses_to_disclose_its_key_share() {
+    let mut rng = rand::thread_rng();
+    let fixture = BlameSenderFixture::new(&mut rng);
+    let mut sender = fixture.accused_sender(&mut rng);
+
+    sender
+        .add_verdict(1, fixture.verdict(&[1]))
+        .expect("accusing verdict");
+    sender
+        .add_verdict(2, fixture.verdict(&[1]))
+        .expect("accusing verdict");
+    sender
+        .add_verdict(3, fixture.verdict(&[]))
+        .expect("ok verdict");
+
+    let error = sender
+        .get_blame_revelation()
+        .expect_err("must refuse to disclose the secret key share");
+    assert!(
+        error.to_string().contains("secret key share"),
+        "unexpected error: {error}"
     );
 }

--- a/threshold-eddsa-babyjubjub/src/reshare/test.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/test.rs
@@ -1,0 +1,392 @@
+//! End-to-end tests for the `ReShare` protocol, covering the handover of a threshold key to a new
+//! set of parties on its own, as well as signing with the resulting key shares.
+
+use crate::{
+    Affine, BaseField, Curve, ScalarField,
+    keygen::{Parameters, finished::Finished, test::run_keygen},
+    reshare::{
+        receiver::ReShareProtocolReceiver, sender::ReShareProtocolSender,
+        sender_set::ReShareSenderSet,
+    },
+    shamir::{secret::DLogShareShamir, test::test_threshold_eddsa_inner, utils::test_utils},
+};
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::UniformRand;
+use eddsa_babyjubjub::EdDSAPublicKey;
+use rand::{CryptoRng, Rng, seq::IteratorRandom as _};
+use uuid::Uuid;
+
+/// Runs the full `ReShare` protocol, handing the key held by `old_parties` over to a new set of
+/// parties described by `new_params`, and returns the final state of every new party.
+///
+/// The set of senders is a random subset of the old parties of the size required by `old_params`.
+fn run_reshare<R: Rng + CryptoRng>(
+    old_parties: &[Finished<Curve>],
+    old_params: Parameters,
+    new_params: Parameters,
+    session_id: Uuid,
+    rng: &mut R,
+) -> Vec<Finished<Curve>> {
+    // 0) The parties agree on the set of old parties handing over the key
+    let senders =
+        (1..=old_params.number_of_parties).choose_multiple(rng, usize::from(old_params.threshold));
+
+    let mut sender_set =
+        ReShareSenderSet::<Curve>::for_pk_and_parameters(old_parties[0].pk, old_params, new_params);
+    for &sender in &senders {
+        assert!(
+            !sender_set.ready(),
+            "the set of senders is not complete yet"
+        );
+        sender_set
+            .add_party(
+                sender,
+                old_parties[party_position(sender)].pk_shares[&sender],
+            )
+            .expect("public key share of an honest party is accepted");
+    }
+    assert!(sender_set.ready(), "the set of senders is complete");
+    sender_set
+        .correct()
+        .expect("the public key shares of the senders recombine to the public key");
+
+    // 1) Every sender re-shares its share of the key with a fresh polynomial and broadcasts the
+    //    commitments to its coefficients
+    let sender_states = senders
+        .iter()
+        .map(|&sender| {
+            ReShareProtocolSender::<Curve>::new(
+                sender,
+                &old_parties[party_position(sender)].sk_share,
+                sender_set.clone(),
+                session_id,
+                rng,
+            )
+            .expect("party index is valid for the old parameters")
+        })
+        .collect::<Vec<_>>();
+
+    let broadcasts = sender_states
+        .iter()
+        .map(ReShareProtocolSender::get_broadcast_message)
+        .collect::<Vec<_>>();
+
+    // 2) Every sender sends the evaluation of its polynomial to the respective new party. This communication can happen in parallel with the broadcast of the commitments.
+    let communications = sender_states
+        .iter()
+        .map(|sender| {
+            (1..=new_params.number_of_parties)
+                .map(|for_party| {
+                    sender
+                        .get_party_communication(for_party)
+                        .expect("party index is valid for the new parameters")
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    // 3) Every new party combines the received shares into its share of the unchanged key
+    (1..=new_params.number_of_parties)
+        .map(|my_idx| {
+            let mut receiver =
+                ReShareProtocolReceiver::<Curve>::new(my_idx, sender_set.clone(), session_id)
+                    .expect("party index is valid for the new parameters");
+            assert_eq!(
+                receiver.get_missing_parties().len(),
+                senders.len(),
+                "no communication of the senders has been added yet"
+            );
+
+            for (position, &from) in senders.iter().enumerate() {
+                receiver
+                    .add_old_party_communication(
+                        from,
+                        broadcasts[position].clone(),
+                        communications[position][party_position(my_idx)].clone(),
+                    )
+                    .expect("secret share of an honest sender verifies against its commitments");
+            }
+            assert!(
+                receiver.get_missing_parties().is_empty(),
+                "the communication of all senders has been added"
+            );
+            assert!(receiver.can_advance(), "the ReShare protocol is complete");
+
+            receiver
+                .finalize()
+                .expect("the ReShare protocol is complete")
+        })
+        .collect()
+}
+
+/// Translates the party index used by the protocol, which starts at one, into a position in the
+/// vector of parties.
+fn party_position(party_id: u16) -> usize {
+    usize::from(party_id) - 1
+}
+
+/// Translates a position in the vector of parties into the party index used by the protocol, which
+/// starts at one.
+fn party_id(position: usize) -> u16 {
+    u16::try_from(position + 1).expect("Fits into u16")
+}
+
+/// Asserts that the parties hold a consistent Shamir sharing of `secret_key` for the given
+/// parameters, and returns the public key they agree on.
+fn assert_consistent_shares<R: Rng>(
+    parties: &[Finished<Curve>],
+    params: Parameters,
+    session_id: Uuid,
+    secret_key: ScalarField,
+    rng: &mut R,
+) -> Affine {
+    let num_parties = params.number_of_parties;
+    let degree = usize::from(params.degree());
+
+    assert_eq!(
+        parties.len(),
+        usize::from(num_parties),
+        "every party finished the protocol"
+    );
+
+    // All parties agree on the session, the public key and the public key shares
+    let public_key = parties[0].pk;
+    for party in parties {
+        assert_eq!(party.session_id, session_id, "session id is preserved");
+        assert_eq!(party.pk, public_key, "parties agree on the public key");
+        assert_eq!(
+            party.pk_shares.len(),
+            usize::from(num_parties),
+            "there is a public key share for every party"
+        );
+        for other_id in 1..=num_parties {
+            assert_eq!(
+                party.pk_shares[&other_id], parties[0].pk_shares[&other_id],
+                "parties agree on the public key share of party {other_id}"
+            );
+        }
+    }
+
+    // The public key share of a party is the public counterpart of its secret key share
+    for (position, party) in parties.iter().enumerate() {
+        let my_id = party_id(position);
+        assert_eq!(party.my_idx, my_id, "the party index is preserved");
+        assert_eq!(
+            party.pk_shares[&my_id],
+            (Affine::generator() * party.sk_share).into_affine(),
+            "public key share of party {my_id} matches its secret key share"
+        );
+    }
+
+    // Any `threshold` of the secret key shares reconstruct the unchanged signing key
+    let sk_shares = parties
+        .iter()
+        .map(|party| party.sk_share)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        test_utils::reconstruct_random_shares(&sk_shares, degree, rng),
+        secret_key,
+        "the reconstructed secret key is unchanged"
+    );
+
+    // The same holds for the public key shares in the exponent
+    let pk_shares = parties
+        .iter()
+        .enumerate()
+        .map(|(position, party)| party.pk_shares[&party_id(position)].into_group())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        test_utils::reconstruct_random_pointshares(&pk_shares, degree, rng).into_affine(),
+        public_key,
+        "reconstructed public key shares match the public key"
+    );
+    assert_eq!(
+        (Affine::generator() * secret_key).into_affine(),
+        public_key,
+        "the public key belongs to the unchanged secret key"
+    );
+
+    public_key
+}
+
+/// Creates a key with the DKG protocol and reshares it to a new set of parties, asserting that the
+/// key is preserved along the way. Returns the final state of every new party.
+fn keygen_and_reshare<R: Rng + CryptoRng>(
+    old_params: Parameters,
+    new_params: Parameters,
+    rng: &mut R,
+) -> Vec<Finished<Curve>> {
+    let keygen_session_id = Uuid::new_v4();
+    let old_parties = run_keygen(
+        old_params.number_of_parties,
+        old_params.threshold,
+        keygen_session_id,
+        rng,
+    );
+    let sk_shares = old_parties
+        .iter()
+        .map(|party| party.sk_share)
+        .collect::<Vec<_>>();
+    let secret_key =
+        test_utils::reconstruct_random_shares(&sk_shares, usize::from(old_params.degree()), rng);
+    let public_key =
+        assert_consistent_shares(&old_parties, old_params, keygen_session_id, secret_key, rng);
+
+    let reshare_session_id = Uuid::new_v4();
+    let new_parties = run_reshare(
+        &old_parties,
+        old_params,
+        new_params,
+        reshare_session_id,
+        rng,
+    );
+    assert_eq!(
+        public_key,
+        assert_consistent_shares(
+            &new_parties,
+            new_params,
+            reshare_session_id,
+            secret_key,
+            rng
+        ),
+        "the public key survives the ReShare protocol"
+    );
+
+    new_parties
+}
+
+/// Creates a signature with the given parties, which hold a Shamir sharing of the signing key for
+/// `params`. The parties at the given positions in the set of signers contribute a malformed
+/// signature share and must be identified by the aggregation.
+fn sign<R: Rng + CryptoRng>(
+    parties: &[Finished<Curve>],
+    params: Parameters,
+    cheating_positions: &[usize],
+    rng: &mut R,
+) {
+    let public_key = EdDSAPublicKey { pk: parties[0].pk };
+    let message = BaseField::rand(rng);
+
+    let x_shares = parties
+        .iter()
+        .map(|party| DLogShareShamir(party.sk_share))
+        .collect::<Vec<_>>();
+    let public_key_shares = (1..=params.number_of_parties)
+        .map(|party_id| parties[0].pk_shares[&party_id])
+        .collect::<Vec<_>>();
+
+    test_threshold_eddsa_inner(
+        usize::from(params.number_of_parties),
+        usize::from(params.degree()),
+        cheating_positions,
+        message,
+        &x_shares,
+        &public_key,
+        &public_key_shares,
+        rng,
+    );
+}
+
+fn test_reshare(old: (u16, u16), new: (u16, u16)) {
+    let mut rng = rand::thread_rng();
+    keygen_and_reshare(
+        Parameters::new(old.0, old.1),
+        Parameters::new(new.0, new.1),
+        &mut rng,
+    );
+}
+
+fn test_reshare_and_sign(old: (u16, u16), new: (u16, u16), cheating_positions: &[usize]) {
+    let mut rng = rand::thread_rng();
+    let new_params = Parameters::new(new.0, new.1);
+    let new_parties = keygen_and_reshare(Parameters::new(old.0, old.1), new_params, &mut rng);
+    sign(&new_parties, new_params, cheating_positions, &mut rng);
+}
+
+/// Creates a key with the DKG protocol, reshares it along the whole chain of parameters and finally
+/// signs with the key shares of the last set of parties.
+fn test_repeated_reshare_and_sign(
+    old: (u16, u16),
+    chain: &[(u16, u16)],
+    cheating_positions: &[usize],
+) {
+    let mut rng = rand::thread_rng();
+
+    let mut params = Parameters::new(old.0, old.1);
+    let new_params = Parameters::new(chain[0].0, chain[0].1);
+    let mut parties = keygen_and_reshare(params, new_params, &mut rng);
+    params = new_params;
+
+    let sk_shares = parties
+        .iter()
+        .map(|party| party.sk_share)
+        .collect::<Vec<_>>();
+    let secret_key =
+        test_utils::reconstruct_random_shares(&sk_shares, usize::from(params.degree()), &mut rng);
+    let public_key = parties[0].pk;
+
+    for &(num_parties, threshold) in &chain[1..] {
+        let new_params = Parameters::new(num_parties, threshold);
+        let session_id = Uuid::new_v4();
+        parties = run_reshare(&parties, params, new_params, session_id, &mut rng);
+        assert_eq!(
+            public_key,
+            assert_consistent_shares(&parties, new_params, session_id, secret_key, &mut rng),
+            "the public key survives repeated runs of the ReShare protocol"
+        );
+        params = new_params;
+    }
+
+    sign(&parties, params, cheating_positions, &mut rng);
+}
+
+#[test]
+fn test_reshare_to_smaller_set() {
+    test_reshare((5, 3), (3, 2));
+}
+
+#[test]
+fn test_reshare_to_bigger_set() {
+    test_reshare((5, 3), (7, 4));
+}
+
+#[test]
+fn test_reshare_to_same_size_set() {
+    test_reshare((5, 3), (5, 3));
+}
+
+#[test]
+fn test_reshare_and_sign_to_smaller_set() {
+    test_reshare_and_sign((5, 3), (3, 2), &[]);
+}
+
+#[test]
+fn test_reshare_and_sign_to_bigger_set() {
+    test_reshare_and_sign((5, 3), (7, 4), &[]);
+}
+
+#[test]
+fn test_reshare_and_sign_to_same_size_set() {
+    test_reshare_and_sign((5, 3), (5, 3), &[]);
+}
+
+#[test]
+fn test_repeated_reshare_and_sign_to_smaller_sets() {
+    test_repeated_reshare_and_sign((7, 5), &[(6, 4), (5, 3), (3, 2)], &[]);
+}
+
+#[test]
+fn test_repeated_reshare_and_sign_to_bigger_sets() {
+    test_repeated_reshare_and_sign((3, 2), &[(5, 3), (6, 4), (7, 5)], &[]);
+}
+
+#[test]
+fn test_repeated_reshare_and_sign_to_same_size_sets() {
+    test_repeated_reshare_and_sign((5, 3), &[(5, 3), (5, 3), (5, 3)], &[]);
+}
+
+#[test]
+fn test_repeated_reshare_and_sign_identifies_cheating_parties() {
+    // The set of parties shrinks and grows again before signing with two cheating parties
+    test_repeated_reshare_and_sign((5, 3), &[(3, 2), (7, 4), (7, 4)], &[0, 2]);
+}

--- a/threshold-eddsa-babyjubjub/src/reshare/test.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/test.rs
@@ -11,7 +11,7 @@ use crate::{
     shamir::{secret::DLogShareShamir, test::test_threshold_eddsa_inner, utils::test_utils},
 };
 use ark_ec::{AffineRepr, CurveGroup};
-use ark_ff::UniformRand;
+use ark_ff::{One, UniformRand};
 use eddsa_babyjubjub::EdDSAPublicKey;
 use rand::{CryptoRng, Rng, seq::IteratorRandom as _};
 use uuid::Uuid;
@@ -389,4 +389,189 @@ fn test_repeated_reshare_and_sign_to_same_size_sets() {
 fn test_repeated_reshare_and_sign_identifies_cheating_parties() {
     // The set of parties shrinks and grows again before signing with two cheating parties
     test_repeated_reshare_and_sign((5, 3), &[(3, 2), (7, 4), (7, 4)], &[0, 2]);
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReShareBlameTestMode {
+    Valid,
+    Malformed,
+    Missing,
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "Exercises the complete optional reshare blame workflow"
+)]
+fn run_reshare_blame_test(
+    mode: ReShareBlameTestMode,
+    old_params: Parameters,
+    new_params: Parameters,
+) {
+    assert!(old_params.number_of_parties > old_params.threshold);
+    let mut rng = rand::thread_rng();
+    let old_parties = run_keygen(
+        old_params.number_of_parties,
+        old_params.threshold,
+        Uuid::new_v4(),
+        &mut rng,
+    );
+    let session_id = Uuid::new_v4();
+    let mut sender_set =
+        ReShareSenderSet::<Curve>::for_pk_and_parameters(old_parties[0].pk, old_params, new_params);
+    for sender in 1..=old_params.number_of_parties {
+        sender_set
+            .add_party(
+                sender,
+                old_parties[party_position(sender)].pk_shares[&sender],
+            )
+            .expect("honest old public-key share");
+    }
+    sender_set
+        .correct()
+        .expect("all old shares reconstruct the key");
+
+    let sender_states = (1..=old_params.number_of_parties)
+        .map(|sender| {
+            ReShareProtocolSender::<Curve>::new(
+                sender,
+                &old_parties[party_position(sender)].sk_share,
+                sender_set.clone(),
+                session_id,
+                &mut rng,
+            )
+            .expect("valid old sender")
+        })
+        .collect::<Vec<_>>();
+    let broadcasts = sender_states
+        .iter()
+        .map(ReShareProtocolSender::get_broadcast_message)
+        .collect::<Vec<_>>();
+    let mut private_shares = sender_states
+        .iter()
+        .map(|sender| {
+            (1..=new_params.number_of_parties)
+                .map(|receiver| {
+                    sender
+                        .get_party_communication(receiver)
+                        .expect("valid new receiver")
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    // Dealer 1 equivocates only toward receiver 2, which will complain publicly.
+    private_shares[0][1].secret_share += ScalarField::one();
+    let mut receivers = (1..=new_params.number_of_parties)
+        .map(|receiver| {
+            let mut state = ReShareProtocolReceiver::new(receiver, sender_set.clone(), session_id)
+                .expect("valid new receiver");
+            for sender in 1..=old_params.number_of_parties {
+                state
+                    .add_old_party_communication_for_blame(
+                        sender,
+                        broadcasts[party_position(sender)].clone(),
+                        private_shares[party_position(sender)][party_position(receiver)].clone(),
+                    )
+                    .expect("sender communication retained for blame");
+            }
+            state.blame_round().expect("all sender messages received")
+        })
+        .collect::<Vec<_>>();
+    let verdicts = receivers
+        .iter()
+        .map(crate::reshare::blame::ReShareBlameRound::verdict)
+        .collect::<Vec<_>>();
+    assert!(verdicts[0].is_ok());
+    assert_eq!(
+        verdicts[1]
+            .blamed_parties()
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![1]
+    );
+    for (receiver, state) in receivers.iter_mut().enumerate() {
+        for (sender, verdict) in verdicts.iter().enumerate() {
+            if receiver != sender {
+                state
+                    .add_verdict(party_id(sender), verdict.clone())
+                    .expect("valid new-party verdict");
+            }
+        }
+    }
+
+    let accusers = receivers[0].accusations().expect("all verdicts received")[&1].clone();
+    let mut revelation = if mode == ReShareBlameTestMode::Missing {
+        None
+    } else {
+        Some(
+            sender_states[0]
+                .get_blame_revelation(&accusers)
+                .expect("accused sender reveals committed shares"),
+        )
+    };
+    if mode == ReShareBlameTestMode::Malformed {
+        revelation
+            .as_mut()
+            .expect("malformed mode has a revelation")
+            .shares[0]
+            .share += ScalarField::one();
+    }
+    for state in &mut receivers {
+        if let Some(revelation) = &revelation {
+            state
+                .add_revelation(1, revelation)
+                .expect("old-sender revelation processed");
+        } else {
+            state
+                .disqualify_missing_sender(1)
+                .expect("missing old sender disqualified");
+        }
+    }
+
+    let results = receivers
+        .into_iter()
+        .map(|state| state.finalize().expect("enough qualified senders survive"))
+        .collect::<Vec<_>>();
+    let expected_disqualified = if mode == ReShareBlameTestMode::Valid {
+        vec![]
+    } else {
+        vec![1]
+    };
+    for result in &results {
+        assert_eq!(result.disqualified_parties, expected_disqualified);
+        assert_eq!(result.finished.pk, old_parties[0].pk);
+        assert_eq!(result.finished.pk_shares, results[0].finished.pk_shares);
+        assert_eq!(
+            (Affine::generator() * result.finished.sk_share).into_affine(),
+            result.finished.pk_shares[&result.finished.my_idx]
+        );
+    }
+}
+
+#[test]
+fn reshare_blame_accepts_valid_sender_revelation() {
+    run_reshare_blame_test(
+        ReShareBlameTestMode::Valid,
+        Parameters::new(4, 2),
+        Parameters::new(3, 2),
+    );
+}
+
+#[test]
+fn reshare_blame_disqualifies_malformed_sender_revelation() {
+    run_reshare_blame_test(
+        ReShareBlameTestMode::Malformed,
+        Parameters::new(4, 2),
+        Parameters::new(3, 2),
+    );
+}
+
+#[test]
+fn reshare_blame_disqualifies_missing_sender_revelation() {
+    run_reshare_blame_test(
+        ReShareBlameTestMode::Missing,
+        Parameters::new(4, 2),
+        Parameters::new(3, 2),
+    );
 }

--- a/threshold-eddsa-babyjubjub/src/reshare/test.rs
+++ b/threshold-eddsa-babyjubjub/src/reshare/test.rs
@@ -841,3 +841,102 @@ fn reshare_sender_refuses_to_disclose_its_key_share() {
         "unexpected error: {error}"
     );
 }
+
+/// Two receivers that survive with different sender sets both pass the public-key check, so only the
+/// agreement digest catches the divergence — and the resulting shares really are incompatible.
+#[test]
+fn divergent_sender_sets_are_caught_only_by_the_agreement_digest() {
+    let mut rng = rand::thread_rng();
+    // Four senders for a threshold of three, so dropping one still reconstructs the old key.
+    let old_params = Parameters::new(4, 3);
+    let new_params = Parameters::new(3, 2);
+    let old_parties = run_keygen(4, 3, Uuid::new_v4(), &mut rng);
+    let sk_shares = old_parties.iter().map(|p| p.sk_share).collect::<Vec<_>>();
+    let secret_key = test_utils::reconstruct_random_shares(&sk_shares, 2, &mut rng);
+
+    let session_id = Uuid::new_v4();
+    let mut sender_set =
+        ReShareSenderSet::<Curve>::for_pk_and_parameters(old_parties[0].pk, old_params, new_params);
+    for id in 1..=4u16 {
+        sender_set
+            .add_party(id, old_parties[party_position(id)].pk_shares[&id])
+            .expect("honest old party");
+    }
+    sender_set.correct().expect("all four senders recombine");
+
+    let senders = (1..=4u16)
+        .map(|id| {
+            ReShareProtocolSender::new(
+                id,
+                &old_parties[party_position(id)].sk_share,
+                sender_set.clone(),
+                session_id,
+                &mut rng,
+            )
+            .expect("valid old sender")
+        })
+        .collect::<Vec<_>>();
+    let broadcasts = senders
+        .iter()
+        .map(ReShareProtocolSender::get_broadcast_message)
+        .collect::<Vec<_>>();
+
+    let finished = (1..=2u16)
+        .map(|receiver| {
+            let mut state = ReShareProtocolReceiver::new(receiver, sender_set.clone(), session_id)
+                .expect("valid new receiver");
+            for sender in 1..=4u16 {
+                // Receiver 2 alone decides sender 4 timed out. Both choices are locally legal.
+                if receiver == 2 && sender == 4 {
+                    state
+                        .disqualify_missing_sender(sender)
+                        .expect("dropping one of four senders preserves the old key");
+                    continue;
+                }
+                let position = party_position(sender);
+                state
+                    .add_old_party_communication(
+                        sender,
+                        broadcasts[position].clone(),
+                        &senders[position]
+                            .get_party_communication(receiver)
+                            .expect("valid new receiver"),
+                    )
+                    .expect("honest sender communication");
+            }
+            state.finalize().expect("both sender sets finalize")
+        })
+        .collect::<Vec<_>>();
+
+    // Every check the protocol performs passes on both sides.
+    assert_eq!(finished[0].pk, old_parties[0].pk);
+    assert_eq!(finished[1].pk, old_parties[0].pk);
+    assert_eq!(finished[0].contributing_parties, vec![1, 2, 3, 4]);
+    assert_eq!(finished[1].contributing_parties, vec![1, 2, 3]);
+
+    assert_ne!(
+        finished[0].agreement_digest(),
+        finished[1].agreement_digest(),
+        "divergent sender sets must yield different agreement digests"
+    );
+
+    // The shares lie on different polynomials, so they no longer interpolate to the signing key.
+    let lagrange = crate::shamir::utils::lagrange_from_coeff::<ScalarField, _>(&[1u16, 2u16]);
+    assert_ne!(
+        test_utils::reconstruct(&[finished[0].sk_share, finished[1].sk_share], &lagrange),
+        secret_key,
+        "shares from divergent sender sets must not reconstruct the key"
+    );
+}
+
+/// An honest run agrees on the digest at every receiver.
+#[test]
+fn matching_reshare_runs_agree_on_the_agreement_digest() {
+    let mut rng = rand::thread_rng();
+    let parties = keygen_and_reshare(Parameters::new(3, 2), Parameters::new(4, 3), &mut rng);
+    let digest = parties[0].agreement_digest();
+    for party in &parties {
+        assert_eq!(party.agreement_digest(), digest);
+        assert_eq!(party.contributing_parties.len(), 2, "old threshold senders");
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/serde_utils.rs
+++ b/threshold-eddsa-babyjubjub/src/serde_utils.rs
@@ -1,0 +1,213 @@
+use std::{collections::BTreeSet, fmt, marker::PhantomData};
+
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, CompressedChecked};
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{Error as _, SeqAccess, Visitor},
+    ser::{Error as _, SerializeSeq},
+};
+
+/// Party identifiers and protocol thresholds are represented as `u16` values,
+/// so no honest participant-sized collection can exceed this limit.
+///
+/// This is a generic ceiling, not a tight bound: the exact expected length is usually
+/// `Parameters::threshold`, but that is not visible to a Serde adapter. A maximally sized
+/// commitment vector therefore still costs one subgroup check per element before the caller's own
+/// length check runs. Reject oversized frames at the transport, as the crate README requires.
+///
+/// Note also that these adapters encode a sequence with per-element framing rather than one
+/// `ark-serialize` blob, so the wire format differs from a plain `CompressedChecked<Vec<_>>`.
+pub(crate) const MAX_PROTOCOL_PARTIES: usize = u16::MAX as usize;
+
+pub(crate) fn serialize_protocol_vec<S, T>(values: &[T], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    if values.len() > MAX_PROTOCOL_PARTIES {
+        return Err(S::Error::custom("protocol collection exceeds u16 limit"));
+    }
+
+    let mut sequence = serializer.serialize_seq(Some(values.len()))?;
+    for value in values {
+        sequence.serialize_element(value)?;
+    }
+    sequence.end()
+}
+
+pub(crate) fn deserialize_protocol_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    deserializer.deserialize_seq(BoundedVecVisitor(PhantomData))
+}
+
+struct BoundedVecVisitor<T>(PhantomData<fn() -> T>);
+
+impl<'de, T> Visitor<'de> for BoundedVecVisitor<T>
+where
+    T: Deserialize<'de>,
+{
+    type Value = Vec<T>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "a sequence containing at most {MAX_PROTOCOL_PARTIES} elements"
+        )
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        reject_oversized_hint(sequence.size_hint(), &self)?;
+
+        let mut values = Vec::new();
+        while let Some(value) = sequence.next_element()? {
+            if values.len() == MAX_PROTOCOL_PARTIES {
+                return Err(A::Error::invalid_length(MAX_PROTOCOL_PARTIES + 1, &self));
+            }
+            values.push(value);
+        }
+        Ok(values)
+    }
+}
+
+pub(crate) fn deserialize_protocol_btree_set<'de, D, T>(
+    deserializer: D,
+) -> Result<BTreeSet<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Ord,
+{
+    deserializer.deserialize_seq(BoundedSetVisitor(PhantomData))
+}
+
+struct BoundedSetVisitor<T>(PhantomData<fn() -> T>);
+
+impl<'de, T> Visitor<'de> for BoundedSetVisitor<T>
+where
+    T: Deserialize<'de> + Ord,
+{
+    type Value = BTreeSet<T>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "a set containing at most {MAX_PROTOCOL_PARTIES} elements"
+        )
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        reject_oversized_hint(sequence.size_hint(), &self)?;
+
+        let mut values = BTreeSet::new();
+        let mut received = 0;
+        while let Some(value) = sequence.next_element()? {
+            if received == MAX_PROTOCOL_PARTIES {
+                return Err(A::Error::invalid_length(MAX_PROTOCOL_PARTIES + 1, &self));
+            }
+            received += 1;
+            values.insert(value);
+        }
+        Ok(values)
+    }
+}
+
+pub(crate) fn serialize_canonical_protocol_vec<S, T>(
+    values: &[T],
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: CanonicalSerialize,
+{
+    if values.len() > MAX_PROTOCOL_PARTIES {
+        return Err(S::Error::custom("protocol collection exceeds u16 limit"));
+    }
+
+    let mut sequence = serializer.serialize_seq(Some(values.len()))?;
+    for value in values {
+        sequence.serialize_element(&CompressedChecked(value))?;
+    }
+    sequence.end()
+}
+
+pub(crate) fn deserialize_canonical_protocol_vec<'de, D, T>(
+    deserializer: D,
+) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: CanonicalDeserialize,
+{
+    deserializer.deserialize_seq(CanonicalVisitor(PhantomData))
+}
+
+struct CanonicalVisitor<T>(PhantomData<fn() -> T>);
+
+impl<'de, T> Visitor<'de> for CanonicalVisitor<T>
+where
+    T: CanonicalDeserialize,
+{
+    type Value = Vec<T>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "a sequence containing at most {MAX_PROTOCOL_PARTIES} canonical elements"
+        )
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        reject_oversized_hint(sequence.size_hint(), &self)?;
+
+        let mut values = Vec::new();
+        while let Some(CompressedChecked(value)) = sequence.next_element()? {
+            if values.len() == MAX_PROTOCOL_PARTIES {
+                return Err(A::Error::invalid_length(MAX_PROTOCOL_PARTIES + 1, &self));
+            }
+            values.push(value);
+        }
+        Ok(values)
+    }
+}
+
+fn reject_oversized_hint<E: serde::de::Error>(
+    size_hint: Option<usize>,
+    expected: &dyn serde::de::Expected,
+) -> Result<(), E> {
+    if size_hint.is_some_and(|length| length > MAX_PROTOCOL_PARTIES) {
+        return Err(E::invalid_length(MAX_PROTOCOL_PARTIES + 1, expected));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ScalarField;
+
+    #[test]
+    fn bounded_collection_deserializers_reject_oversized_sequences() {
+        let oversized =
+            serde_json::Value::Array(vec![serde_json::Value::from(1); MAX_PROTOCOL_PARTIES + 1]);
+
+        let Err(_) = deserialize_protocol_vec::<_, u16>(oversized.clone()) else {
+            panic!("an oversized protocol vector must be rejected");
+        };
+        let Err(_) = deserialize_protocol_btree_set::<_, u16>(oversized.clone()) else {
+            panic!("an oversized protocol set must be rejected");
+        };
+        let Err(_) = deserialize_canonical_protocol_vec::<_, ScalarField>(oversized) else {
+            panic!("an oversized canonical protocol vector must be rejected");
+        };
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/session.rs
+++ b/threshold-eddsa-babyjubjub/src/session.rs
@@ -20,6 +20,7 @@ use zeroize::ZeroizeOnDrop;
 /// The `challenge` method consumes the session.
 #[derive(ZeroizeOnDrop)]
 pub struct EdDSASession {
+    pub(crate) party_id: u16,
     pub(crate) d: ScalarField,
     pub(crate) e: ScalarField,
 }
@@ -27,19 +28,29 @@ pub struct EdDSASession {
 impl EdDSASession {
     /// Computes commitments to two random values `d_share` and `e_share`, which will be the shares of the randomness used in the `EdDSA` signature.
     /// The result is meant to be sent to one accumulating party (i.e., the aggregator) who combines all the shares of all parties and creates the challenge hash.
-    pub fn pre_round(rng: &mut (impl CryptoRng + Rng)) -> (Self, PartialEdDSACommitments) {
+    ///
+    /// # Errors
+    /// Returns an error if `party_id` is zero.
+    pub fn pre_round(
+        party_id: u16,
+        rng: &mut (impl CryptoRng + Rng),
+    ) -> eyre::Result<(Self, PartialEdDSACommitments)> {
+        if party_id == 0 {
+            eyre::bail!("party ID must be non-zero");
+        }
         let d_share: ark_ff::Fp<ark_ff::MontBackend<ark_babyjubjub::FrConfig, 4>, 4> =
             ScalarField::rand(rng);
         let e_share = ScalarField::rand(rng);
         let d = (Affine::generator() * d_share).into_affine();
         let e = (Affine::generator() * e_share).into_affine();
-        let comm = PartialEdDSACommitments { d, e };
+        let comm = PartialEdDSACommitments { party_id, d, e };
 
         let session = EdDSASession {
+            party_id,
             d: d_share,
             e: e_share,
         };
 
-        (session, comm)
+        Ok((session, comm))
     }
 }

--- a/threshold-eddsa-babyjubjub/src/session.rs
+++ b/threshold-eddsa-babyjubjub/src/session.rs
@@ -1,0 +1,45 @@
+//! Per-Party Session State for Threshold `EdDSA`
+//!
+//! This module defines the `EdDSASession` struct, which holds the secret two-nonce randomness a
+//! party samples in the pre-round and consumes again when producing its signature share.
+//!
+//! The primitives defined here are agnostic to the underlying threshold sharing scheme and are used by both
+//! additive and Shamir variants, which are implemented in their respective submodules `additive` and `shamir`.
+//!
+//! Secret randomness is never clonable, and session types deliberately do not implement `Debug` to avoid accidental leakage.
+
+use crate::{Affine, ScalarField, partial_commit::PartialEdDSACommitments};
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::UniformRand;
+use rand::{CryptoRng, Rng};
+use zeroize::ZeroizeOnDrop;
+
+/// The internal storage of a party in a distributed `EdDSA` protocol.
+///
+/// This is not `Clone` because it contains secret randomness that may only be used once. We also don't implement `Debug` so we do don't print it by accident.
+/// The `challenge` method consumes the session.
+#[derive(ZeroizeOnDrop)]
+pub struct EdDSASession {
+    pub(crate) d: ScalarField,
+    pub(crate) e: ScalarField,
+}
+
+impl EdDSASession {
+    /// Computes commitments to two random values `d_share` and `e_share`, which will be the shares of the randomness used in the `EdDSA` signature.
+    /// The result is meant to be sent to one accumulating party (i.e., the aggregator) who combines all the shares of all parties and creates the challenge hash.
+    pub fn pre_round(rng: &mut (impl CryptoRng + Rng)) -> (Self, PartialEdDSACommitments) {
+        let d_share: ark_ff::Fp<ark_ff::MontBackend<ark_babyjubjub::FrConfig, 4>, 4> =
+            ScalarField::rand(rng);
+        let e_share = ScalarField::rand(rng);
+        let d = (Affine::generator() * d_share).into_affine();
+        let e = (Affine::generator() * e_share).into_affine();
+        let comm = PartialEdDSACommitments { d, e };
+
+        let session = EdDSASession {
+            d: d_share,
+            e: e_share,
+        };
+
+        (session, comm)
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/shamir/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/commit.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use ark_ec::CurveGroup;
 use ark_ff::Zero;
+use ark_serialize::Valid;
 use eddsa_babyjubjub::{EdDSAPublicKey, EdDSASignature};
 use itertools::izip;
 use serde::{Deserialize, Serialize};
@@ -29,8 +30,16 @@ pub struct EdDSACommitmentsShamir(pub(crate) EdDSACommitments);
 
 impl EdDSACommitmentsShamir {
     /// Create an aggregated commitment object from component affine points and party IDs.
+    ///
+    /// # Panics
+    /// Panics if a commitment is invalid, or if party IDs are empty, zero, or duplicated.
     #[must_use]
     pub fn new(d: Affine, e: Affine, parties: Vec<u16>) -> Self {
+        assert!(
+            d.check().is_ok() && e.check().is_ok(),
+            "commitments must be valid subgroup points"
+        );
+        EdDSACommitments::validate_party_ids(&parties);
         let commitments = EdDSACommitments {
             d,
             e,
@@ -48,6 +57,9 @@ impl EdDSACommitmentsShamir {
     /// Combine all parties' signature shares into a single `EdDSA` signature object.
     ///
     /// Must use the same order of contributing parties as in aggregation
+    ///
+    /// # Panics
+    /// Panics unless exactly one signature share is supplied per contributing party.
     #[must_use]
     pub fn sign_agg(
         self,
@@ -56,6 +68,11 @@ impl EdDSACommitmentsShamir {
         message: BaseField,
         public_key: EdDSAPublicKey,
     ) -> EdDSASignature {
+        assert_eq!(
+            shares.len(),
+            self.0.contributing_parties.len(),
+            "one share is required per contributing party"
+        );
         self.0
             .sign_agg(session_id, shares.iter().map(|x| &x.0), message, public_key)
     }
@@ -63,20 +80,16 @@ impl EdDSACommitmentsShamir {
     /// Combine all parties' signature shares into a single `EdDSA` signature object, verifying
     /// each party's contribution individually so that malformed shares can be attributed.
     ///
-    /// The order of `shares`, `commitments`, and `x_share_commitments` must match the order of the
-    /// Lagrange coefficients.
+    /// The order of `shares`, `commitments`, and `x_share_commitments` must match
+    /// `contributing_parties`. Lagrange coefficients are derived internally.
     ///
     /// # Errors
     /// Returns a [`MaliciousPartiesError`] with the IDs of all parties whose signature share does
     /// not verify against their commitment and their Lagrange-weighted share of the public key.
     ///
     /// # Panics
-    /// Panics if `shares`, `x_share_commitments`, `commitments` and `lagrange_coefficients` do not
-    /// all have the same length. The call site is expected to enforce this.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "Keeps consistency with the additive version of this function"
-    )]
+    /// Panics if the supplied vectors do not match the validated contributing-party set, or if
+    /// their individual public values do not reconstruct the stored aggregates.
     pub fn sign_agg_with_identifiable_abort(
         self,
         session_id: Uuid,
@@ -85,7 +98,6 @@ impl EdDSACommitmentsShamir {
         public_key: &EdDSAPublicKey,
         x_share_commitments: &[Affine],
         commitments: &[PartialEdDSACommitmentsShamir],
-        lagrange_coefficients: &[ScalarField],
     ) -> Result<EdDSASignature, MaliciousPartiesError> {
         assert_eq!(
             shares.len(),
@@ -99,8 +111,45 @@ impl EdDSACommitmentsShamir {
         );
         assert_eq!(
             shares.len(),
-            lagrange_coefficients.len(),
-            "Shares and lagrange coefficients must match"
+            self.0.contributing_parties.len(),
+            "one share is required per contributing party"
+        );
+        EdDSACommitments::validate_party_ids(&self.0.contributing_parties);
+        let lagrange_coefficients = self
+            .0
+            .contributing_parties
+            .iter()
+            .map(|party| {
+                crate::shamir::utils::single_lagrange_from_coeff::<ScalarField, _>(
+                    *party,
+                    &self.0.contributing_parties,
+                )
+            })
+            .collect::<Vec<_>>();
+        let (individual_d, individual_e) = commitments.iter().fold(
+            (Projective::zero(), Projective::zero()),
+            |(d, e), commitment| (d + commitment.0.d, e + commitment.0.e),
+        );
+        assert_eq!(
+            individual_d.into_affine(),
+            self.0.d,
+            "individual and aggregate d commitments differ"
+        );
+        assert_eq!(
+            individual_e.into_affine(),
+            self.0.e,
+            "individual and aggregate e commitments differ"
+        );
+        let reconstructed_pk = x_share_commitments
+            .iter()
+            .zip(&lagrange_coefficients)
+            .fold(Projective::zero(), |acc, (point, lambda)| {
+                acc + *point * lambda
+            });
+        assert_eq!(
+            reconstructed_pk.into_affine(),
+            public_key.pk,
+            "public-key shares do not reconstruct the public key"
         );
 
         let (r, b) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
@@ -124,7 +173,7 @@ impl EdDSACommitmentsShamir {
             shares,
             x_share_commitments,
             commitments,
-            lagrange_coefficients
+            &lagrange_coefficients
         )
         .enumerate()
         {
@@ -166,14 +215,7 @@ impl EdDSACommitmentsShamir {
         commitments: &[PartialEdDSACommitmentsShamir],
         contributing_parties: Vec<u16>,
     ) -> Self {
-        let mut contributing_parties_dedup = contributing_parties.clone();
-        contributing_parties_dedup.sort_unstable();
-        contributing_parties_dedup.dedup();
-        assert_eq!(
-            contributing_parties.len(),
-            contributing_parties_dedup.len(),
-            "Party IDs must be unique"
-        );
+        EdDSACommitments::validate_party_ids(&contributing_parties);
         assert_eq!(
             contributing_parties.len(),
             commitments.len(),

--- a/threshold-eddsa-babyjubjub/src/shamir/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/commit.rs
@@ -6,7 +6,7 @@
 //! the parties that contributed a malformed share.
 
 use crate::{
-    Affine, BaseField, CheatingPartiesError, Projective, ScalarField,
+    Affine, BaseField, MaliciousPartiesError, Projective, ScalarField,
     commit::EdDSACommitments,
     nonce::CombineTwoNonceRandomnessArgs,
     shamir::{partial_commit::PartialEdDSACommitmentsShamir, signature::EdDSASigShareShamir},
@@ -67,7 +67,7 @@ impl EdDSACommitmentsShamir {
     /// Lagrange coefficients.
     ///
     /// # Errors
-    /// Returns a [`CheatingPartiesError`] with the IDs of all parties whose signature share does
+    /// Returns a [`MaliciousPartiesError`] with the IDs of all parties whose signature share does
     /// not verify against their commitment and their Lagrange-weighted share of the public key.
     ///
     /// # Panics
@@ -86,7 +86,7 @@ impl EdDSACommitmentsShamir {
         x_share_commitments: &[Affine],
         commitments: &[PartialEdDSACommitmentsShamir],
         lagrange_coefficients: &[ScalarField],
-    ) -> Result<EdDSASignature, CheatingPartiesError> {
+    ) -> Result<EdDSASignature, MaliciousPartiesError> {
         assert_eq!(
             shares.len(),
             x_share_commitments.len(),
@@ -141,7 +141,7 @@ impl EdDSACommitmentsShamir {
         }
 
         if !cheating_parties.is_empty() {
-            return Err(CheatingPartiesError(cheating_parties));
+            return Err(MaliciousPartiesError(cheating_parties));
         }
 
         // Finally assemble the signature

--- a/threshold-eddsa-babyjubjub/src/shamir/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/commit.rs
@@ -17,6 +17,7 @@ use ark_serialize::Valid;
 use eddsa_babyjubjub::{EdDSAPublicKey, EdDSASignature};
 use itertools::izip;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use uuid::Uuid;
 
 /// Commitment aggregation object for the Shamir `EdDSA` protocol.
@@ -31,21 +32,20 @@ pub struct EdDSACommitmentsShamir(pub(crate) EdDSACommitments);
 impl EdDSACommitmentsShamir {
     /// Create an aggregated commitment object from component affine points and party IDs.
     ///
-    /// # Panics
-    /// Panics if a commitment is invalid, or if party IDs are empty, zero, or duplicated.
-    #[must_use]
-    pub fn new(d: Affine, e: Affine, parties: Vec<u16>) -> Self {
-        assert!(
-            d.check().is_ok() && e.check().is_ok(),
-            "commitments must be valid subgroup points"
-        );
-        EdDSACommitments::validate_party_ids(&parties);
+    /// # Errors
+    /// Returns an error if a commitment is invalid, or if party IDs are empty, zero, duplicated,
+    /// or not canonically ordered.
+    pub fn new(d: Affine, e: Affine, parties: Vec<u16>) -> eyre::Result<Self> {
+        if d.check().is_err() || e.check().is_err() {
+            eyre::bail!("commitments must be valid subgroup points");
+        }
+        EdDSACommitments::validate_party_ids(&parties)?;
         let commitments = EdDSACommitments {
             d,
             e,
             contributing_parties: parties,
         };
-        Self(commitments)
+        Ok(Self(commitments))
     }
 
     /// Returns the parties that contributed to this commitment.
@@ -56,65 +56,61 @@ impl EdDSACommitmentsShamir {
 
     /// Combine all parties' signature shares into a single `EdDSA` signature object.
     ///
-    /// Must use the same order of contributing parties as in aggregation
+    /// Signature shares are matched to the contributing set by their embedded party IDs.
     ///
-    /// # Panics
-    /// Panics unless exactly one signature share is supplied per contributing party.
-    #[must_use]
+    /// # Errors
+    /// Returns an error unless exactly one signature share is supplied for each contributing
+    /// party.
     pub fn sign_agg(
         self,
         session_id: Uuid,
         shares: &[EdDSASigShareShamir],
         message: BaseField,
         public_key: EdDSAPublicKey,
-    ) -> EdDSASignature {
-        assert_eq!(
-            shares.len(),
-            self.0.contributing_parties.len(),
-            "one share is required per contributing party"
-        );
-        self.0
-            .sign_agg(session_id, shares.iter().map(|x| &x.0), message, public_key)
+    ) -> eyre::Result<EdDSASignature> {
+        let shares = self.ordered_shares(shares)?;
+        Ok(self.0.sign_agg(
+            session_id,
+            shares.into_iter().map(|share| &share.0),
+            message,
+            public_key,
+        ))
     }
 
     /// Combine all parties' signature shares into a single `EdDSA` signature object, verifying
     /// each party's contribution individually so that malformed shares can be attributed.
     ///
-    /// The order of `shares`, `commitments`, and `x_share_commitments` must match
-    /// `contributing_parties`. Lagrange coefficients are derived internally.
+    /// Signature shares and nonce commitments carry party IDs. Public-key shares are keyed by ID.
+    /// Lagrange coefficients are derived internally.
     ///
     /// # Errors
     /// Returns a [`MaliciousPartiesError`] with the IDs of all parties whose signature share does
     /// not verify against their commitment and their Lagrange-weighted share of the public key.
     ///
-    /// # Panics
-    /// Panics if the supplied vectors do not match the validated contributing-party set, or if
-    /// their individual public values do not reconstruct the stored aggregates.
     pub fn sign_agg_with_identifiable_abort(
         self,
         session_id: Uuid,
         shares: &[EdDSASigShareShamir],
         message: BaseField,
         public_key: &EdDSAPublicKey,
-        x_share_commitments: &[Affine],
+        x_share_commitments: &BTreeMap<u16, Affine>,
         commitments: &[PartialEdDSACommitmentsShamir],
-    ) -> Result<EdDSASignature, MaliciousPartiesError> {
-        assert_eq!(
-            shares.len(),
-            x_share_commitments.len(),
-            "Shares and commitments must match"
-        );
-        assert_eq!(
-            shares.len(),
-            commitments.len(),
-            "Shares and commitments must match"
-        );
-        assert_eq!(
-            shares.len(),
-            self.0.contributing_parties.len(),
-            "one share is required per contributing party"
-        );
-        EdDSACommitments::validate_party_ids(&self.0.contributing_parties);
+    ) -> eyre::Result<EdDSASignature> {
+        EdDSACommitments::validate_party_ids(&self.0.contributing_parties)?;
+        let shares = self.ordered_shares(shares)?;
+        let commitment_by_party = commitments
+            .iter()
+            .map(|commitment| (commitment.party_id(), commitment))
+            .collect::<BTreeMap<_, _>>();
+        if commitment_by_party.len() != commitments.len()
+            || commitment_by_party.keys().copied().collect::<Vec<_>>()
+                != self.0.contributing_parties
+        {
+            eyre::bail!("nonce commitments do not match the contributing party set");
+        }
+        if x_share_commitments.keys().copied().collect::<Vec<_>>() != self.0.contributing_parties {
+            eyre::bail!("public-key shares do not match the contributing party set");
+        }
         let lagrange_coefficients = self
             .0
             .contributing_parties
@@ -126,31 +122,22 @@ impl EdDSACommitmentsShamir {
                 )
             })
             .collect::<Vec<_>>();
-        let (individual_d, individual_e) = commitments.iter().fold(
+        let (individual_d, individual_e) = commitment_by_party.values().fold(
             (Projective::zero(), Projective::zero()),
             |(d, e), commitment| (d + commitment.0.d, e + commitment.0.e),
         );
-        assert_eq!(
-            individual_d.into_affine(),
-            self.0.d,
-            "individual and aggregate d commitments differ"
-        );
-        assert_eq!(
-            individual_e.into_affine(),
-            self.0.e,
-            "individual and aggregate e commitments differ"
-        );
+        if individual_d.into_affine() != self.0.d || individual_e.into_affine() != self.0.e {
+            eyre::bail!("individual and aggregate nonce commitments differ");
+        }
         let reconstructed_pk = x_share_commitments
-            .iter()
+            .values()
             .zip(&lagrange_coefficients)
             .fold(Projective::zero(), |acc, (point, lambda)| {
                 acc + *point * lambda
             });
-        assert_eq!(
-            reconstructed_pk.into_affine(),
-            public_key.pk,
-            "public-key shares do not reconstruct the public key"
-        );
+        if reconstructed_pk.into_affine() != public_key.pk {
+            eyre::bail!("public-key shares do not reconstruct the public key");
+        }
 
         let (r, b) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
             session_id,
@@ -170,14 +157,14 @@ impl EdDSACommitmentsShamir {
         // For identifiable abort, we check the contribution of all parties
         let mut cheating_parties = Vec::new();
         for (id, (share, x_share_commitment, commitment, lagrange)) in izip!(
-            shares,
-            x_share_commitments,
-            commitments,
+            &shares,
+            x_share_commitments.values(),
+            commitment_by_party.values(),
             &lagrange_coefficients
         )
         .enumerate()
         {
-            let s = share.0.0;
+            let s = share.0.1;
             let r = commitment.0.d + commitment.0.e * b;
             if !crate::commit::verify_for_identifiable_abort(
                 x_share_commitment,
@@ -190,42 +177,39 @@ impl EdDSACommitmentsShamir {
         }
 
         if !cheating_parties.is_empty() {
-            return Err(MaliciousPartiesError(cheating_parties));
+            eyre::bail!(MaliciousPartiesError(cheating_parties));
         }
 
         // Finally assemble the signature
         let mut s = ScalarField::zero();
         for share in shares {
-            s += share.0.0;
+            s += share.0.1;
         }
 
         let sig = EdDSASignature { r, s };
         Ok(sig)
     }
 
-    /// The accumulating party (i.e., the aggregatir) combines the shares of `d + 1` parties.
+    /// The accumulating party combines a threshold-sized set of identity-bound commitments.
     ///
-    /// # Panics
-    /// Panics if the number of commitments does not match the number of contributing parties,
-    /// i.e. `commitments.len() != contributing_parties.len()`.
-    /// Additionally, panics if the contributing parties contain duplicate party IDs.
-    /// The call site is expected to enforce these checks.
-    #[must_use]
-    pub fn pre_agg(
-        commitments: &[PartialEdDSACommitmentsShamir],
-        contributing_parties: Vec<u16>,
-    ) -> Self {
-        EdDSACommitments::validate_party_ids(&contributing_parties);
-        assert_eq!(
-            contributing_parties.len(),
-            commitments.len(),
-            "Number of commitments must match number of contributing parties"
-        );
+    /// # Errors
+    /// Returns an error for an empty set or duplicate/invalid party IDs.
+    pub fn pre_agg(commitments: &[PartialEdDSACommitmentsShamir]) -> eyre::Result<Self> {
+        let input_len = commitments.len();
+        let commitments = commitments
+            .iter()
+            .map(|commitment| (commitment.party_id(), commitment))
+            .collect::<BTreeMap<_, _>>();
+        let contributing_parties = commitments.keys().copied().collect::<Vec<_>>();
+        if commitments.len() != input_len {
+            eyre::bail!("duplicate nonce commitment party ID");
+        }
+        EdDSACommitments::validate_party_ids(&contributing_parties)?;
 
         let mut d = Projective::zero();
         let mut e = Projective::zero();
 
-        for PartialEdDSACommitmentsShamir(comm) in commitments {
+        for PartialEdDSACommitmentsShamir(comm) in commitments.values() {
             d += comm.d;
             e += comm.e;
         }
@@ -239,6 +223,22 @@ impl EdDSACommitmentsShamir {
             contributing_parties,
         };
 
-        EdDSACommitmentsShamir(commitments)
+        Ok(EdDSACommitmentsShamir(commitments))
+    }
+
+    fn ordered_shares<'a>(
+        &self,
+        shares: &'a [EdDSASigShareShamir],
+    ) -> eyre::Result<Vec<&'a EdDSASigShareShamir>> {
+        let shares = shares
+            .iter()
+            .map(|share| (share.party_id(), share))
+            .collect::<BTreeMap<_, _>>();
+        if shares.len() != self.0.contributing_parties.len()
+            || shares.keys().copied().collect::<Vec<_>>() != self.0.contributing_parties
+        {
+            eyre::bail!("signature shares do not match the contributing party set");
+        }
+        Ok(shares.into_values().collect())
     }
 }

--- a/threshold-eddsa-babyjubjub/src/shamir/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/commit.rs
@@ -109,10 +109,14 @@ impl EdDSACommitmentsShamir {
             || commitment_by_party.keys().copied().collect::<Vec<_>>()
                 != self.0.contributing_parties
         {
-            return Err(eyre::eyre!("nonce commitments do not match the contributing party set").into());
+            return Err(
+                eyre::eyre!("nonce commitments do not match the contributing party set").into(),
+            );
         }
         if x_share_commitments.keys().copied().collect::<Vec<_>>() != self.0.contributing_parties {
-            return Err(eyre::eyre!("public-key shares do not match the contributing party set").into());
+            return Err(
+                eyre::eyre!("public-key shares do not match the contributing party set").into(),
+            );
         }
         let lagrange_coefficients = self
             .0
@@ -194,6 +198,13 @@ impl EdDSACommitmentsShamir {
     }
 
     /// The accumulating party combines a threshold-sized set of identity-bound commitments.
+    ///
+    /// Duplicate party IDs are rejected, but two distinct IDs presenting the same `(d, e)` pair are
+    /// not. This follows Frost3, which drops the duplicate-presignature abort of Frost2-CKM on the
+    /// grounds that authenticated, confidential signer-to-aggregator channels rule out copying.
+    /// Unforgeability is unaffected — a copied commitment cannot yield a share that passes
+    /// `sign_agg_with_identifiable_abort` — but a copy shows up as a failed share rather than as a
+    /// duplicate.
     ///
     /// # Errors
     /// Returns an error for an empty set or duplicate/invalid party IDs.

--- a/threshold-eddsa-babyjubjub/src/shamir/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/commit.rs
@@ -6,7 +6,7 @@
 //! the parties that contributed a malformed share.
 
 use crate::{
-    Affine, BaseField, MaliciousPartiesError, Projective, ScalarField,
+    Affine, BaseField, IdentifiableAbortError, MaliciousPartiesError, Projective, ScalarField,
     commit::EdDSACommitments,
     nonce::CombineTwoNonceRandomnessArgs,
     shamir::{partial_commit::PartialEdDSACommitmentsShamir, signature::EdDSASigShareShamir},
@@ -84,9 +84,12 @@ impl EdDSACommitmentsShamir {
     /// Lagrange coefficients are derived internally.
     ///
     /// # Errors
-    /// Returns a [`MaliciousPartiesError`] with the IDs of all parties whose signature share does
-    /// not verify against their commitment and their Lagrange-weighted share of the public key.
-    ///
+    /// Returns [`IdentifiableAbortError::MaliciousParties`] with the IDs of all parties whose
+    /// signature share does not verify against their commitment and their Lagrange-weighted share of
+    /// the public key. Returns [`IdentifiableAbortError::InvalidInput`] when the supplied shares,
+    /// commitments, or public-key shares do not match the contributing party set, do not sum to the
+    /// stored aggregate, or do not reconstruct the public key — in that case no share was validated
+    /// and no participant may be accused.
     pub fn sign_agg_with_identifiable_abort(
         self,
         session_id: Uuid,
@@ -95,7 +98,7 @@ impl EdDSACommitmentsShamir {
         public_key: &EdDSAPublicKey,
         x_share_commitments: &BTreeMap<u16, Affine>,
         commitments: &[PartialEdDSACommitmentsShamir],
-    ) -> eyre::Result<EdDSASignature> {
+    ) -> Result<EdDSASignature, IdentifiableAbortError> {
         EdDSACommitments::validate_party_ids(&self.0.contributing_parties)?;
         let shares = self.ordered_shares(shares)?;
         let commitment_by_party = commitments
@@ -106,10 +109,10 @@ impl EdDSACommitmentsShamir {
             || commitment_by_party.keys().copied().collect::<Vec<_>>()
                 != self.0.contributing_parties
         {
-            eyre::bail!("nonce commitments do not match the contributing party set");
+            return Err(eyre::eyre!("nonce commitments do not match the contributing party set").into());
         }
         if x_share_commitments.keys().copied().collect::<Vec<_>>() != self.0.contributing_parties {
-            eyre::bail!("public-key shares do not match the contributing party set");
+            return Err(eyre::eyre!("public-key shares do not match the contributing party set").into());
         }
         let lagrange_coefficients = self
             .0
@@ -127,7 +130,7 @@ impl EdDSACommitmentsShamir {
             |(d, e), commitment| (d + commitment.0.d, e + commitment.0.e),
         );
         if individual_d.into_affine() != self.0.d || individual_e.into_affine() != self.0.e {
-            eyre::bail!("individual and aggregate nonce commitments differ");
+            return Err(eyre::eyre!("individual and aggregate nonce commitments differ").into());
         }
         let reconstructed_pk = x_share_commitments
             .values()
@@ -136,7 +139,7 @@ impl EdDSACommitmentsShamir {
                 acc + *point * lambda
             });
         if reconstructed_pk.into_affine() != public_key.pk {
-            eyre::bail!("public-key shares do not reconstruct the public key");
+            return Err(eyre::eyre!("public-key shares do not reconstruct the public key").into());
         }
 
         let (r, b) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
@@ -177,7 +180,7 @@ impl EdDSACommitmentsShamir {
         }
 
         if !cheating_parties.is_empty() {
-            eyre::bail!(MaliciousPartiesError(cheating_parties));
+            return Err(MaliciousPartiesError(cheating_parties).into());
         }
 
         // Finally assemble the signature

--- a/threshold-eddsa-babyjubjub/src/shamir/commit.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/commit.rs
@@ -1,0 +1,202 @@
+//! Aggregated commitments for the Shamir threshold `EdDSA` protocol.
+//!
+//! This module defines the `EdDSACommitmentsShamir` struct, which sums the per-party commitment
+//! shares of the `d + 1` contributing parties and combines the received signature shares into the
+//! final `EdDSA` signature. It also offers an aggregation with identifiable abort, which pinpoints
+//! the parties that contributed a malformed share.
+
+use crate::{
+    Affine, BaseField, CheatingPartiesError, Projective, ScalarField,
+    commit::EdDSACommitments,
+    nonce::CombineTwoNonceRandomnessArgs,
+    shamir::{partial_commit::PartialEdDSACommitmentsShamir, signature::EdDSASigShareShamir},
+};
+use ark_ec::CurveGroup;
+use ark_ff::Zero;
+use eddsa_babyjubjub::{EdDSAPublicKey, EdDSASignature};
+use itertools::izip;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Commitment aggregation object for the Shamir `EdDSA` protocol.
+///
+/// This is a transparent wrapper around the core `EdDSACommitments` struct, grouping
+/// together the aggregate commitments and participating party identifiers as reconstructed
+/// via Shamir Lagrange interpolation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EdDSACommitmentsShamir(pub(crate) EdDSACommitments);
+
+impl EdDSACommitmentsShamir {
+    /// Create an aggregated commitment object from component affine points and party IDs.
+    #[must_use]
+    pub fn new(d: Affine, e: Affine, parties: Vec<u16>) -> Self {
+        let commitments = EdDSACommitments {
+            d,
+            e,
+            contributing_parties: parties,
+        };
+        Self(commitments)
+    }
+
+    /// Returns the parties that contributed to this commitment.
+    #[must_use]
+    pub fn get_contributing_parties(&self) -> &[u16] {
+        &self.0.contributing_parties
+    }
+
+    /// Combine all parties' signature shares into a single `EdDSA` signature object.
+    ///
+    /// Must use the same order of contributing parties as in aggregation
+    #[must_use]
+    pub fn sign_agg(
+        self,
+        session_id: Uuid,
+        shares: &[EdDSASigShareShamir],
+        message: BaseField,
+        public_key: EdDSAPublicKey,
+    ) -> EdDSASignature {
+        self.0
+            .sign_agg(session_id, shares.iter().map(|x| &x.0), message, public_key)
+    }
+
+    /// Combine all parties' signature shares into a single `EdDSA` signature object, verifying
+    /// each party's contribution individually so that malformed shares can be attributed.
+    ///
+    /// The order of `shares`, `commitments`, and `x_share_commitments` must match the order of the
+    /// Lagrange coefficients.
+    ///
+    /// # Errors
+    /// Returns a [`CheatingPartiesError`] with the IDs of all parties whose signature share does
+    /// not verify against their commitment and their Lagrange-weighted share of the public key.
+    ///
+    /// # Panics
+    /// Panics if `shares`, `x_share_commitments`, `commitments` and `lagrange_coefficients` do not
+    /// all have the same length. The call site is expected to enforce this.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Keeps consistency with the additive version of this function"
+    )]
+    pub fn sign_agg_with_identifiable_abort(
+        self,
+        session_id: Uuid,
+        shares: &[EdDSASigShareShamir],
+        message: BaseField,
+        public_key: &EdDSAPublicKey,
+        x_share_commitments: &[Affine],
+        commitments: &[PartialEdDSACommitmentsShamir],
+        lagrange_coefficients: &[ScalarField],
+    ) -> Result<EdDSASignature, CheatingPartiesError> {
+        assert_eq!(
+            shares.len(),
+            x_share_commitments.len(),
+            "Shares and commitments must match"
+        );
+        assert_eq!(
+            shares.len(),
+            commitments.len(),
+            "Shares and commitments must match"
+        );
+        assert_eq!(
+            shares.len(),
+            lagrange_coefficients.len(),
+            "Shares and lagrange coefficients must match"
+        );
+
+        let (r, b) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
+            session_id,
+            message,
+            public_key: public_key.to_owned(),
+            d: self.0.d,
+            e: self.0.e,
+            parties: &self.0.contributing_parties,
+        });
+
+        // Recompute the challenge hash to ensure the challenge is well-formed.
+        let c = eddsa_babyjubjub::challenge_hash(message, r, public_key.pk);
+
+        // The following modular reduction in convert_base_to_scalar is required in rust to perform the scalar multiplications. Using all 254 bits of the base field in a double/add ladder would apply this reduction implicitly. We show in the docs of convert_base_to_scalar why this does not introduce a bias when applied to a uniform element of the base field.
+        let c_ = eddsa_babyjubjub::convert_base_to_scalar(c);
+
+        // For identifiable abort, we check the contribution of all parties
+        let mut cheating_parties = Vec::new();
+        for (id, (share, x_share_commitment, commitment, lagrange)) in izip!(
+            shares,
+            x_share_commitments,
+            commitments,
+            lagrange_coefficients
+        )
+        .enumerate()
+        {
+            let s = share.0.0;
+            let r = commitment.0.d + commitment.0.e * b;
+            if !crate::commit::verify_for_identifiable_abort(
+                x_share_commitment,
+                r.into_affine(),
+                s,
+                c_ * lagrange,
+            ) {
+                cheating_parties.push(usize::from(self.0.contributing_parties[id]));
+            }
+        }
+
+        if !cheating_parties.is_empty() {
+            return Err(CheatingPartiesError(cheating_parties));
+        }
+
+        // Finally assemble the signature
+        let mut s = ScalarField::zero();
+        for share in shares {
+            s += share.0.0;
+        }
+
+        let sig = EdDSASignature { r, s };
+        Ok(sig)
+    }
+
+    /// The accumulating party (i.e., the aggregatir) combines the shares of `d + 1` parties.
+    ///
+    /// # Panics
+    /// Panics if the number of commitments does not match the number of contributing parties,
+    /// i.e. `commitments.len() != contributing_parties.len()`.
+    /// Additionally, panics if the contributing parties contain duplicate party IDs.
+    /// The call site is expected to enforce these checks.
+    #[must_use]
+    pub fn pre_agg(
+        commitments: &[PartialEdDSACommitmentsShamir],
+        contributing_parties: Vec<u16>,
+    ) -> Self {
+        let mut contributing_parties_dedup = contributing_parties.clone();
+        contributing_parties_dedup.sort_unstable();
+        contributing_parties_dedup.dedup();
+        assert_eq!(
+            contributing_parties.len(),
+            contributing_parties_dedup.len(),
+            "Party IDs must be unique"
+        );
+        assert_eq!(
+            contributing_parties.len(),
+            commitments.len(),
+            "Number of commitments must match number of contributing parties"
+        );
+
+        let mut d = Projective::zero();
+        let mut e = Projective::zero();
+
+        for PartialEdDSACommitmentsShamir(comm) in commitments {
+            d += comm.d;
+            e += comm.e;
+        }
+
+        let d = d.into_affine();
+        let e = e.into_affine();
+
+        let commitments = EdDSACommitments {
+            d,
+            e,
+            contributing_parties,
+        };
+
+        EdDSACommitmentsShamir(commitments)
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/shamir/mod.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/mod.rs
@@ -1,0 +1,17 @@
+//! Threshold `EdDSA` with Shamir secret sharing.
+//!
+//! This module implements the `t`-out-of-`n` variant of the protocol, where the signing key is
+//! shared via a polynomial of degree `d`, so any `d + 1` parties can jointly produce a signature
+//! by weighting their shares with the matching Lagrange coefficients.
+//!
+//! The types defined in the submodules are thin wrappers around the scheme-agnostic primitives in
+//! the crate root modules `commit`, `nonce`, `partial_commit`, `session` and `signature`.
+
+pub mod commit;
+pub mod partial_commit;
+pub mod secret;
+pub mod session;
+pub mod signature;
+#[cfg(test)]
+pub mod test;
+pub(crate) mod utils;

--- a/threshold-eddsa-babyjubjub/src/shamir/partial_commit.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/partial_commit.rs
@@ -1,0 +1,16 @@
+//! Per-party commitments for the Shamir threshold `EdDSA` protocol.
+//!
+//! This module defines the `PartialEdDSACommitmentsShamir` struct, the commitment share a single
+//! party sends to the aggregator in the pre-round.
+
+use crate::partial_commit::PartialEdDSACommitments;
+use serde::{Deserialize, Serialize};
+
+/// Per-party commitment shares for Shamir `EdDSA` protocol.
+///
+/// Wraps and serializes individual party commitments to the distributed `EdDSA` signature,
+/// in the context of Shamir secret sharing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[repr(transparent)]
+#[serde(transparent)]
+pub struct PartialEdDSACommitmentsShamir(pub(crate) PartialEdDSACommitments);

--- a/threshold-eddsa-babyjubjub/src/shamir/partial_commit.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/partial_commit.rs
@@ -14,3 +14,11 @@ use serde::{Deserialize, Serialize};
 #[repr(transparent)]
 #[serde(transparent)]
 pub struct PartialEdDSACommitmentsShamir(pub(crate) PartialEdDSACommitments);
+
+impl PartialEdDSACommitmentsShamir {
+    /// Return the party ID carried by this commitment.
+    #[must_use]
+    pub fn party_id(&self) -> u16 {
+        self.0.party_id()
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/shamir/secret.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/secret.rs
@@ -16,17 +16,44 @@ use zeroize::ZeroizeOnDrop;
 /// Not `Debug`/`Display` to avoid accidental leaks.
 ///
 #[derive(Serialize, Deserialize, ZeroizeOnDrop, CanonicalSerialize, CanonicalDeserialize)]
-#[serde(transparent)]
-pub struct DLogShareShamir(#[serde(with = "ark_serde_compat::field")] pub(crate) ScalarField);
-
-impl From<ark_babyjubjub::Fr> for DLogShareShamir {
-    fn from(value: ark_babyjubjub::Fr) -> Self {
-        Self(value)
-    }
+pub struct DLogShareShamir {
+    #[serde(with = "ark_serde_compat::field")]
+    pub(crate) value: ScalarField,
+    pub(crate) party_id: u16,
+    pub(crate) number_of_parties: u16,
+    pub(crate) threshold: u16,
 }
 
-impl From<DLogShareShamir> for ark_babyjubjub::Fr {
-    fn from(value: DLogShareShamir) -> Self {
-        value.0
+impl DLogShareShamir {
+    /// Bind a scalar share to its party identity and Shamir committee parameters.
+    ///
+    /// # Errors
+    /// Returns an error unless the metadata satisfies
+    /// `1 <= party_id <= number_of_parties` and
+    /// `1 <= threshold <= number_of_parties`.
+    pub fn new(
+        value: ScalarField,
+        party_id: u16,
+        number_of_parties: u16,
+        threshold: u16,
+    ) -> eyre::Result<Self> {
+        if party_id == 0 || number_of_parties == 0 || party_id > number_of_parties {
+            eyre::bail!("party ID must lie in the non-empty Shamir party set");
+        }
+        if threshold == 0 || threshold > number_of_parties {
+            eyre::bail!("invalid Shamir threshold");
+        }
+        Ok(Self {
+            value,
+            party_id,
+            number_of_parties,
+            threshold,
+        })
+    }
+
+    /// Return the identity bound to this share.
+    #[must_use]
+    pub fn party_id(&self) -> u16 {
+        self.party_id
     }
 }

--- a/threshold-eddsa-babyjubjub/src/shamir/secret.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/secret.rs
@@ -1,0 +1,34 @@
+//! Shamir shares of the `EdDSA` signing key.
+//!
+//! This module defines the `DLogShareShamir` struct, one party's Shamir share of the discrete
+//! logarithm of the public key, i.e., the evaluation of the sharing polynomial at the party's
+//! index.
+
+use crate::ScalarField;
+use ark_serialize::CanonicalDeserialize;
+use ark_serialize::CanonicalSerialize;
+use serde::{Deserialize, Serialize};
+use zeroize::ZeroizeOnDrop;
+
+/// Shamir Secret-share of an `EdDSA` signing secret.
+///
+/// Serializable so it can be persisted via a secret manager.
+/// Not `Debug`/`Display` to avoid accidental leaks.
+///
+#[derive(
+    Clone, Serialize, Deserialize, ZeroizeOnDrop, CanonicalSerialize, CanonicalDeserialize,
+)]
+#[serde(transparent)]
+pub struct DLogShareShamir(#[serde(with = "ark_serde_compat::field")] pub(crate) ScalarField);
+
+impl From<ark_babyjubjub::Fr> for DLogShareShamir {
+    fn from(value: ark_babyjubjub::Fr) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DLogShareShamir> for ark_babyjubjub::Fr {
+    fn from(value: DLogShareShamir) -> Self {
+        value.0
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/shamir/secret.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/secret.rs
@@ -4,56 +4,137 @@
 //! logarithm of the public key, i.e., the evaluation of the sharing polynomial at the party's
 //! index.
 
-use crate::ScalarField;
-use ark_serialize::CanonicalDeserialize;
-use ark_serialize::CanonicalSerialize;
-use serde::{Deserialize, Serialize};
+use crate::{Affine, ScalarField};
+use ark_ec::AffineRepr;
+use ark_serde_compat::babyjubjub;
+use ark_serialize::Valid;
+use eddsa_babyjubjub::EdDSAPublicKey;
+use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
 use zeroize::ZeroizeOnDrop;
 
 /// Shamir Secret-share of an `EdDSA` signing secret.
 ///
+/// The scalar is bound to the identity, committee parameters, and public key it belongs to, so
+/// [`sign_round`](crate::shamir::session::EdDSASessionShamir::sign_round) can check every one of
+/// them instead of trusting a caller-supplied argument. Deserialization enforces the same
+/// invariants as [`DLogShareShamir::new`].
+///
 /// Serializable so it can be persisted via a secret manager.
 /// Not `Debug`/`Display` to avoid accidental leaks.
-///
-#[derive(Serialize, Deserialize, ZeroizeOnDrop, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Serialize, ZeroizeOnDrop)]
 pub struct DLogShareShamir {
     #[serde(with = "ark_serde_compat::field")]
     pub(crate) value: ScalarField,
+    #[serde(with = "babyjubjub::affine")]
+    #[zeroize(skip)]
+    pub(crate) public_key: Affine,
     pub(crate) party_id: u16,
     pub(crate) number_of_parties: u16,
     pub(crate) threshold: u16,
 }
 
 impl DLogShareShamir {
-    /// Bind a scalar share to its party identity and Shamir committee parameters.
+    /// Bind a scalar share to its party identity, Shamir committee parameters, and public key.
     ///
     /// # Errors
-    /// Returns an error unless the metadata satisfies
-    /// `1 <= party_id <= number_of_parties` and
-    /// `1 <= threshold <= number_of_parties`.
+    /// Returns an error unless the metadata satisfies `1 <= party_id <= number_of_parties` and
+    /// `1 <= threshold <= number_of_parties`, and `public_key` is a non-zero point in the
+    /// prime-order subgroup.
     pub fn new(
         value: ScalarField,
+        public_key: &EdDSAPublicKey,
         party_id: u16,
         number_of_parties: u16,
         threshold: u16,
     ) -> eyre::Result<Self> {
-        if party_id == 0 || number_of_parties == 0 || party_id > number_of_parties {
-            eyre::bail!("party ID must lie in the non-empty Shamir party set");
-        }
-        if threshold == 0 || threshold > number_of_parties {
-            eyre::bail!("invalid Shamir threshold");
-        }
+        Self::validate(&public_key.pk, party_id, number_of_parties, threshold)?;
         Ok(Self {
             value,
+            public_key: public_key.pk,
             party_id,
             number_of_parties,
             threshold,
         })
     }
 
+    fn validate(
+        public_key: &Affine,
+        party_id: u16,
+        number_of_parties: u16,
+        threshold: u16,
+    ) -> eyre::Result<()> {
+        if party_id == 0 || number_of_parties == 0 || party_id > number_of_parties {
+            eyre::bail!("party ID must lie in the non-empty Shamir party set");
+        }
+        if threshold == 0 || threshold > number_of_parties {
+            eyre::bail!("invalid Shamir threshold");
+        }
+        if public_key.is_zero() || public_key.check().is_err() {
+            eyre::bail!("public key must be a non-zero point in the prime-order subgroup");
+        }
+        Ok(())
+    }
+
     /// Return the identity bound to this share.
     #[must_use]
     pub fn party_id(&self) -> u16 {
         self.party_id
+    }
+
+    /// Return the public key this share belongs to.
+    #[must_use]
+    pub fn public_key(&self) -> EdDSAPublicKey {
+        EdDSAPublicKey {
+            pk: self.public_key,
+        }
+    }
+
+    /// Return the threshold of the sharing this share belongs to.
+    #[must_use]
+    pub fn threshold(&self) -> u16 {
+        self.threshold
+    }
+}
+
+impl<'de> Deserialize<'de> for DLogShareShamir {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Repr {
+            #[serde(with = "ark_serde_compat::field")]
+            value: ScalarField,
+            #[serde(with = "babyjubjub::affine")]
+            public_key: Affine,
+            party_id: u16,
+            number_of_parties: u16,
+            threshold: u16,
+        }
+
+        // The intermediate representation holds the secret scalar, so clear it rather than leaving a
+        // copy in freed memory. Every field is `Copy`, so reading them out below still works.
+        impl Drop for Repr {
+            fn drop(&mut self) {
+                use zeroize::Zeroize as _;
+                self.value.zeroize();
+            }
+        }
+
+        let repr = Repr::deserialize(deserializer)?;
+        DLogShareShamir::validate(
+            &repr.public_key,
+            repr.party_id,
+            repr.number_of_parties,
+            repr.threshold,
+        )
+        .map_err(D::Error::custom)?;
+        Ok(Self {
+            value: repr.value,
+            public_key: repr.public_key,
+            party_id: repr.party_id,
+            number_of_parties: repr.number_of_parties,
+            threshold: repr.threshold,
+        })
     }
 }

--- a/threshold-eddsa-babyjubjub/src/shamir/secret.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/secret.rs
@@ -15,9 +15,7 @@ use zeroize::ZeroizeOnDrop;
 /// Serializable so it can be persisted via a secret manager.
 /// Not `Debug`/`Display` to avoid accidental leaks.
 ///
-#[derive(
-    Clone, Serialize, Deserialize, ZeroizeOnDrop, CanonicalSerialize, CanonicalDeserialize,
-)]
+#[derive(Serialize, Deserialize, ZeroizeOnDrop, CanonicalSerialize, CanonicalDeserialize)]
 #[serde(transparent)]
 pub struct DLogShareShamir(#[serde(with = "ark_serde_compat::field")] pub(crate) ScalarField);
 

--- a/threshold-eddsa-babyjubjub/src/shamir/session.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/session.rs
@@ -1,0 +1,72 @@
+//! Per-party session state for the Shamir threshold `EdDSA` protocol.
+//!
+//! This module defines the `EdDSASessionShamir` struct, which holds the secret two-nonce
+//! randomness of one party between the pre-round and the signing round.
+//!
+//! Secret randomness is never clonable, and session types deliberately do not implement `Debug` to avoid accidental leakage.
+
+use crate::{
+    BaseField, ScalarField,
+    nonce::CombineTwoNonceRandomnessArgs,
+    session::EdDSASession,
+    shamir::{
+        commit::EdDSACommitmentsShamir, partial_commit::PartialEdDSACommitmentsShamir,
+        secret::DLogShareShamir, signature::EdDSASigShareShamir,
+    },
+    signature::EdDSASigShare,
+};
+use eddsa_babyjubjub::EdDSAPublicKey;
+use rand::{CryptoRng, Rng};
+use uuid::Uuid;
+use zeroize::ZeroizeOnDrop;
+
+/// Wrapper for the internal `EdDSA` session state in the Shamir-sharing variant.
+///
+/// Stores non-clonable, non-debug secret state for a threshold party during the `EdDSA` protocol.
+/// Used to generate the commitment shares and construct the signature share for Shamir secret sharing.
+#[derive(ZeroizeOnDrop)]
+pub struct EdDSASessionShamir(EdDSASession);
+
+impl EdDSASessionShamir {
+    /// Computes commitments to two random values `d_share` and `e_share`, which will be the shares of the randomness used in the `EdDSA` signature.
+    /// The result is meant to be sent to one accumulating party (i.e., the aggregator) who combines all the shares of all parties and creates the challenge hash.
+    pub fn pre_round(rng: &mut (impl CryptoRng + Rng)) -> (Self, PartialEdDSACommitmentsShamir) {
+        let (session, comm) = EdDSASession::pre_round(rng);
+        (Self(session), PartialEdDSACommitmentsShamir(comm))
+    }
+
+    /// Finalizes a signature share for a given challenge hash and session.
+    /// The session and information therein is consumed to prevent reuse of the randomness.
+    ///
+    /// Prerequisites:
+    /// * The `lagrange_coefficient` is computed from the same set of contributing parties as in the commitments.
+    /// * The set of contributing parties in `challenge_input` is checked for duplicates, has the correct number of parties and contains the party corresponding to this session.
+    #[must_use]
+    pub fn sign_round(
+        self,
+        session_id: Uuid,
+        DLogShareShamir(x_share): DLogShareShamir,
+        message: BaseField,
+        public_key: &EdDSAPublicKey,
+        EdDSACommitmentsShamir(challenge_input): EdDSACommitmentsShamir,
+        lagrange_coefficient: ScalarField,
+    ) -> EdDSASigShareShamir {
+        // Recombine the two-nonce randomness shares into the full randomness used in the challenge.
+        let (r, b) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
+            session_id,
+            message,
+            public_key: public_key.clone(),
+            d: challenge_input.d,
+            e: challenge_input.e,
+            parties: &challenge_input.contributing_parties,
+        });
+
+        // Recompute the challenge hash to ensure the challenge is well-formed.
+        let c = eddsa_babyjubjub::challenge_hash(message, r, public_key.pk);
+
+        // The following modular reduction in convert_base_to_scalar is required in rust to perform the scalar multiplications. Using all 254 bits of the base field in a double/add ladder would apply this reduction implicitly. We show in the docs of convert_base_to_scalar why this does not introduce a bias when applied to a uniform element of the base field.
+        let c_ = eddsa_babyjubjub::convert_base_to_scalar(c);
+        let share = EdDSASigShare(self.0.d + b * self.0.e + lagrange_coefficient * c_ * x_share);
+        EdDSASigShareShamir(share)
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/shamir/session.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/session.rs
@@ -30,18 +30,27 @@ pub struct EdDSASessionShamir(EdDSASession);
 impl EdDSASessionShamir {
     /// Computes commitments to two random values `d_share` and `e_share`, which will be the shares of the randomness used in the `EdDSA` signature.
     /// The result is meant to be sent to one accumulating party (i.e., the aggregator) who combines all the shares of all parties and creates the challenge hash.
-    pub fn pre_round(rng: &mut (impl CryptoRng + Rng)) -> (Self, PartialEdDSACommitmentsShamir) {
-        let (session, comm) = EdDSASession::pre_round(rng);
-        (Self(session), PartialEdDSACommitmentsShamir(comm))
+    ///
+    /// # Errors
+    /// Returns an error if `party_id` is zero.
+    pub fn pre_round(
+        party_id: u16,
+        rng: &mut (impl CryptoRng + Rng),
+    ) -> eyre::Result<(Self, PartialEdDSACommitmentsShamir)> {
+        let (session, comm) = EdDSASession::pre_round(party_id, rng)?;
+        Ok((Self(session), PartialEdDSACommitmentsShamir(comm)))
     }
 
     /// Finalizes a signature share for a given challenge hash and session.
     /// The session and information therein is consumed to prevent reuse of the randomness.
     ///
-    /// Prerequisites:
-    /// * The `lagrange_coefficient` is computed from the same set of contributing parties as in the commitments.
-    /// * The set of contributing parties in `challenge_input` is checked for duplicates, has the correct number of parties and contains the party corresponding to this session.
-    #[must_use]
+    /// The Lagrange coefficient is derived internally from the identity-bound key share and the
+    /// canonical contributing set.
+    ///
+    /// # Errors
+    /// Returns an error if the key-share metadata is invalid, the signing set is non-canonical,
+    /// outside the key's committee, or smaller than its threshold, or the nonce session, key share,
+    /// and signing set do not identify the same party.
     pub fn sign_round(
         self,
         session_id: Uuid,
@@ -49,8 +58,33 @@ impl EdDSASessionShamir {
         message: BaseField,
         public_key: &EdDSAPublicKey,
         EdDSACommitmentsShamir(challenge_input): EdDSACommitmentsShamir,
-        lagrange_coefficient: ScalarField,
-    ) -> EdDSASigShareShamir {
+    ) -> eyre::Result<EdDSASigShareShamir> {
+        let parties = &challenge_input.contributing_parties;
+        crate::commit::EdDSACommitments::validate_party_ids(parties)?;
+        if x_share.party_id == 0
+            || x_share.number_of_parties == 0
+            || x_share.party_id > x_share.number_of_parties
+            || x_share.threshold == 0
+            || x_share.threshold > x_share.number_of_parties
+        {
+            eyre::bail!("invalid Shamir key-share metadata");
+        }
+        if parties.last().copied().unwrap_or_default() > x_share.number_of_parties {
+            eyre::bail!("signing set contains a party outside the key's committee");
+        }
+        if parties.len() < usize::from(x_share.threshold) {
+            eyre::bail!("signing set is smaller than the threshold bound to the key share");
+        }
+        if self.0.party_id != x_share.party_id {
+            eyre::bail!("nonce session and key share belong to different parties");
+        }
+        if parties.binary_search(&x_share.party_id).is_err() {
+            eyre::bail!("signing set does not contain this party");
+        }
+        let lagrange_coefficient = crate::shamir::utils::single_lagrange_from_coeff::<ScalarField, _>(
+            x_share.party_id,
+            parties,
+        );
         // Recombine the two-nonce randomness shares into the full randomness used in the challenge.
         let (r, b) = crate::nonce::combine_two_nonce_randomness(CombineTwoNonceRandomnessArgs {
             session_id,
@@ -66,7 +100,10 @@ impl EdDSASessionShamir {
 
         // The following modular reduction in convert_base_to_scalar is required in rust to perform the scalar multiplications. Using all 254 bits of the base field in a double/add ladder would apply this reduction implicitly. We show in the docs of convert_base_to_scalar why this does not introduce a bias when applied to a uniform element of the base field.
         let c_ = eddsa_babyjubjub::convert_base_to_scalar(c);
-        let share = EdDSASigShare(self.0.d + b * self.0.e + lagrange_coefficient * c_ * x_share.0);
-        EdDSASigShareShamir(share)
+        let share = EdDSASigShare(
+            x_share.party_id,
+            self.0.d + b * self.0.e + lagrange_coefficient * c_ * x_share.value,
+        );
+        Ok(EdDSASigShareShamir(share))
     }
 }

--- a/threshold-eddsa-babyjubjub/src/shamir/session.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/session.rs
@@ -45,7 +45,7 @@ impl EdDSASessionShamir {
     pub fn sign_round(
         self,
         session_id: Uuid,
-        DLogShareShamir(x_share): DLogShareShamir,
+        x_share: &DLogShareShamir,
         message: BaseField,
         public_key: &EdDSAPublicKey,
         EdDSACommitmentsShamir(challenge_input): EdDSACommitmentsShamir,
@@ -66,7 +66,7 @@ impl EdDSASessionShamir {
 
         // The following modular reduction in convert_base_to_scalar is required in rust to perform the scalar multiplications. Using all 254 bits of the base field in a double/add ladder would apply this reduction implicitly. We show in the docs of convert_base_to_scalar why this does not introduce a bias when applied to a uniform element of the base field.
         let c_ = eddsa_babyjubjub::convert_base_to_scalar(c);
-        let share = EdDSASigShare(self.0.d + b * self.0.e + lagrange_coefficient * c_ * x_share);
+        let share = EdDSASigShare(self.0.d + b * self.0.e + lagrange_coefficient * c_ * x_share.0);
         EdDSASigShareShamir(share)
     }
 }

--- a/threshold-eddsa-babyjubjub/src/shamir/session.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/session.rs
@@ -15,7 +15,6 @@ use crate::{
     },
     signature::EdDSASigShare,
 };
-use eddsa_babyjubjub::EdDSAPublicKey;
 use rand::{CryptoRng, Rng};
 use uuid::Uuid;
 use zeroize::ZeroizeOnDrop;
@@ -44,8 +43,9 @@ impl EdDSASessionShamir {
     /// Finalizes a signature share for a given challenge hash and session.
     /// The session and information therein is consumed to prevent reuse of the randomness.
     ///
-    /// The Lagrange coefficient is derived internally from the identity-bound key share and the
-    /// canonical contributing set.
+    /// The Lagrange coefficient and the public key are both derived from the identity-bound key
+    /// share rather than taken as arguments, so the signer never signs against a committee or a key
+    /// it cannot check.
     ///
     /// # Errors
     /// Returns an error if the key-share metadata is invalid, the signing set is non-canonical,
@@ -56,9 +56,9 @@ impl EdDSASessionShamir {
         session_id: Uuid,
         x_share: &DLogShareShamir,
         message: BaseField,
-        public_key: &EdDSAPublicKey,
         EdDSACommitmentsShamir(challenge_input): EdDSACommitmentsShamir,
     ) -> eyre::Result<EdDSASigShareShamir> {
+        let public_key = x_share.public_key();
         let parties = &challenge_input.contributing_parties;
         crate::commit::EdDSACommitments::validate_party_ids(parties)?;
         if x_share.party_id == 0
@@ -92,7 +92,7 @@ impl EdDSASessionShamir {
             public_key: public_key.clone(),
             d: challenge_input.d,
             e: challenge_input.e,
-            parties: &challenge_input.contributing_parties,
+            parties,
         });
 
         // Recompute the challenge hash to ensure the challenge is well-formed.

--- a/threshold-eddsa-babyjubjub/src/shamir/signature.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/signature.rs
@@ -1,0 +1,14 @@
+//! Signature shares for the Shamir threshold `EdDSA` protocol.
+//!
+//! This module defines the `EdDSASigShareShamir` struct, one party's Lagrange-weighted share of
+//! the response `s` of the final `EdDSA` signature.
+
+use crate::signature::EdDSASigShare;
+use serde::{Deserialize, Serialize};
+
+/// Individual party's signature share for the Shamir `EdDSA` signature protocol.
+///
+/// Wraps the share of the challenge response for Shamir secret sharing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EdDSASigShareShamir(pub(crate) EdDSASigShare);

--- a/threshold-eddsa-babyjubjub/src/shamir/signature.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/signature.rs
@@ -12,3 +12,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct EdDSASigShareShamir(pub(crate) EdDSASigShare);
+
+impl EdDSASigShareShamir {
+    /// Return the party ID bound into this signature share.
+    #[must_use]
+    pub fn party_id(&self) -> u16 {
+        self.0.0
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/shamir/test.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/test.rs
@@ -13,7 +13,7 @@ use crate::{
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::UniformRand;
 use eddsa_babyjubjub::EdDSAPublicKey;
-use rand::{Rng, seq::IteratorRandom};
+use rand::{CryptoRng, Rng, seq::IteratorRandom};
 use uuid::Uuid;
 
 fn share<R: Rng>(
@@ -35,34 +35,30 @@ fn share<R: Rng>(
     shares
 }
 
-fn test_threshold_eddsa(num_parties: usize, degree: usize, cheating_positions: &[usize]) {
-    let mut rng = rand::thread_rng();
-
-    let message = BaseField::rand(&mut rng);
-    let x = ScalarField::rand(&mut rng);
-    let x_shares = share(x, num_parties, degree, &mut rng);
-
-    // Create public keys
-    let public_key = (Affine::generator() * x).into_affine();
-    let public_key_shares = x_shares
-        .iter()
-        .map(|x| Affine::generator() * x.0)
-        .collect::<Vec<_>>();
-    let public_key_ =
-        utils::test_utils::reconstruct_random_pointshares(&public_key_shares, degree, &mut rng);
-    assert_eq!(public_key, public_key_);
-    let public_key = EdDSAPublicKey { pk: public_key };
-
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Shared test driver for the plain and the DKG-based signing flow"
+)]
+pub(crate) fn test_threshold_eddsa_inner<R: Rng + CryptoRng>(
+    num_parties: usize,
+    degree: usize,
+    cheating_positions: &[usize],
+    message: BaseField,
+    x_shares: &[DLogShareShamir],
+    public_key: &EdDSAPublicKey,
+    public_key_shares: &[Affine],
+    rng: &mut R,
+) {
     // Crete session and choose the used set of parties
     let session_id = Uuid::new_v4();
-    let used_parties = (1..=u16::try_from(num_parties).expect("Fits into u16"))
-        .choose_multiple(&mut rng, degree + 1);
+    let used_parties =
+        (1..=u16::try_from(num_parties).expect("Fits into u16")).choose_multiple(rng, degree + 1);
 
     // 1) Aggregator requests commitments from all servers
     let mut sessions = Vec::with_capacity(num_parties);
     let mut commitments = Vec::with_capacity(num_parties);
     for _ in 0..num_parties {
-        let (session, comm) = EdDSASessionShamir::pre_round(&mut rng);
+        let (session, comm) = EdDSASessionShamir::pre_round(rng);
         sessions.push(Some(session));
         commitments.push(comm);
     }
@@ -91,7 +87,7 @@ fn test_threshold_eddsa(num_parties: usize, degree: usize, cheating_positions: &
             session_id,
             x_,
             message,
-            &public_key,
+            public_key,
             challenge.clone(),
             lagrange,
         );
@@ -106,7 +102,7 @@ fn test_threshold_eddsa(num_parties: usize, degree: usize, cheating_positions: &
     // 4) Aggregator combines received signature shares
     let used_public_key_shares = used_parties
         .iter()
-        .map(|&party_id| public_key_shares[usize::from(party_id) - 1].into_affine())
+        .map(|&party_id| public_key_shares[usize::from(party_id) - 1])
         .collect::<Vec<_>>();
 
     // Without identifiable abort
@@ -120,7 +116,7 @@ fn test_threshold_eddsa(num_parties: usize, degree: usize, cheating_positions: &
         session_id,
         &used_sigs,
         message,
-        &public_key,
+        public_key,
         &used_public_key_shares,
         &used_commitments,
         &lagrange_coefficients,
@@ -141,6 +137,41 @@ fn test_threshold_eddsa(num_parties: usize, degree: usize, cheating_positions: &
         }
         assert!(!public_key.verify(message, &signature_noabort));
     }
+}
+
+fn test_threshold_eddsa(num_parties: usize, degree: usize, cheating_positions: &[usize]) {
+    let mut rng = rand::thread_rng();
+
+    let message = BaseField::rand(&mut rng);
+    let x = ScalarField::rand(&mut rng);
+    let x_shares = share(x, num_parties, degree, &mut rng);
+
+    // Create public keys
+    let public_key = (Affine::generator() * x).into_affine();
+    let public_key_shares = x_shares
+        .iter()
+        .map(|x| Affine::generator() * x.0)
+        .collect::<Vec<_>>();
+    let public_key_ =
+        utils::test_utils::reconstruct_random_pointshares(&public_key_shares, degree, &mut rng);
+    assert_eq!(public_key, public_key_);
+    let public_key = EdDSAPublicKey { pk: public_key };
+
+    let public_key_shares = public_key_shares
+        .iter()
+        .map(|&pk_share| pk_share.into_affine())
+        .collect::<Vec<_>>();
+
+    test_threshold_eddsa_inner(
+        num_parties,
+        degree,
+        cheating_positions,
+        message,
+        &x_shares,
+        &public_key,
+        &public_key_shares,
+        &mut rng,
+    );
 }
 
 #[test]

--- a/threshold-eddsa-babyjubjub/src/shamir/test.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/test.rs
@@ -1,0 +1,159 @@
+//! End-to-end tests for the Shamir threshold `EdDSA` protocol, covering both plain aggregation
+//! and aggregation with identifiable abort.
+
+use crate::{
+    Affine, BaseField, ScalarField,
+    shamir::{
+        commit::EdDSACommitmentsShamir,
+        secret::DLogShareShamir,
+        session::EdDSASessionShamir,
+        utils::{self, evaluate_poly},
+    },
+};
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::UniformRand;
+use eddsa_babyjubjub::EdDSAPublicKey;
+use rand::{Rng, seq::IteratorRandom};
+use uuid::Uuid;
+
+fn share<R: Rng>(
+    secret: ScalarField,
+    num_shares: usize,
+    degree: usize,
+    rng: &mut R,
+) -> Vec<DLogShareShamir> {
+    let mut shares: Vec<DLogShareShamir> = Vec::with_capacity(num_shares);
+    let mut coeffs = Vec::with_capacity(degree + 1);
+    coeffs.push(secret);
+    for _ in 0..degree {
+        coeffs.push(ScalarField::rand(rng));
+    }
+    for i in 1..=num_shares {
+        let share = evaluate_poly(&coeffs, ScalarField::from(i as u64));
+        shares.push(DLogShareShamir(share));
+    }
+    shares
+}
+
+fn test_threshold_eddsa(num_parties: usize, degree: usize, cheating_positions: &[usize]) {
+    let mut rng = rand::thread_rng();
+
+    let message = BaseField::rand(&mut rng);
+    let x = ScalarField::rand(&mut rng);
+    let x_shares = share(x, num_parties, degree, &mut rng);
+
+    // Create public keys
+    let public_key = (Affine::generator() * x).into_affine();
+    let public_key_shares = x_shares
+        .iter()
+        .map(|x| Affine::generator() * x.0)
+        .collect::<Vec<_>>();
+    let public_key_ =
+        utils::test_utils::reconstruct_random_pointshares(&public_key_shares, degree, &mut rng);
+    assert_eq!(public_key, public_key_);
+    let public_key = EdDSAPublicKey { pk: public_key };
+
+    // Crete session and choose the used set of parties
+    let session_id = Uuid::new_v4();
+    let used_parties = (1..=u16::try_from(num_parties).expect("Fits into u16"))
+        .choose_multiple(&mut rng, degree + 1);
+
+    // 1) Aggregator requests commitments from all servers
+    let mut sessions = Vec::with_capacity(num_parties);
+    let mut commitments = Vec::with_capacity(num_parties);
+    for _ in 0..num_parties {
+        let (session, comm) = EdDSASessionShamir::pre_round(&mut rng);
+        sessions.push(Some(session));
+        commitments.push(comm);
+    }
+
+    // 2) Aggregator accumulates commitments and creates challenge
+    // Choose the commitments of the used parties
+    let used_commitments = used_parties
+        .iter()
+        .map(|&i| commitments[i as usize - 1].clone())
+        .collect::<Vec<_>>();
+
+    let challenge = EdDSACommitmentsShamir::pre_agg(&used_commitments, used_parties.clone());
+
+    // 3) Aggregator challenges used used parties
+    let mut used_sigs = Vec::with_capacity(num_parties);
+    let mut lagrange_coefficients = Vec::with_capacity(num_parties);
+
+    for server_idx in &used_parties {
+        // we just use an option here in tests to be able to move out of the vector since the session is consumed
+        let session = sessions[*server_idx as usize - 1]
+            .take()
+            .expect("have not used this session before");
+        let x_ = x_shares[*server_idx as usize - 1].clone();
+        let lagrange = utils::single_lagrange_from_coeff(*server_idx, &used_parties);
+        let proof = session.sign_round(
+            session_id,
+            x_,
+            message,
+            &public_key,
+            challenge.clone(),
+            lagrange,
+        );
+        used_sigs.push(proof);
+        lagrange_coefficients.push(lagrange);
+    }
+
+    for &position in cheating_positions {
+        used_sigs[position].0.0 += ScalarField::from(1_u64);
+    }
+
+    // 4) Aggregator combines received signature shares
+    let used_public_key_shares = used_parties
+        .iter()
+        .map(|&party_id| public_key_shares[usize::from(party_id) - 1].into_affine())
+        .collect::<Vec<_>>();
+
+    // Without identifiable abort
+    let signature_noabort =
+        challenge
+            .clone()
+            .sign_agg(session_id, &used_sigs, message, public_key.clone());
+
+    // With identifiable abort
+    let result = challenge.sign_agg_with_identifiable_abort(
+        session_id,
+        &used_sigs,
+        message,
+        &public_key,
+        &used_public_key_shares,
+        &used_commitments,
+        &lagrange_coefficients,
+    );
+
+    if cheating_positions.is_empty() {
+        let signature = result.expect("honest parties produce a signature");
+        assert!(public_key.verify(message, &signature));
+        assert!(public_key.verify(message, &signature_noabort));
+    } else {
+        let expected = cheating_positions
+            .iter()
+            .map(|&position| usize::from(used_parties[position]))
+            .collect::<Vec<_>>();
+        match result {
+            Err(error) => assert_eq!(error.into_inner(), expected),
+            Ok(_) => panic!("cheating parties must be identified"),
+        }
+        assert!(!public_key.verify(message, &signature_noabort));
+    }
+}
+
+#[test]
+fn test_threshold_eddsa_shamir_3_1() {
+    test_threshold_eddsa(3, 1, &[]);
+}
+
+#[test]
+fn test_threshold_eddsa_shamir_31_15() {
+    test_threshold_eddsa(31, 15, &[]);
+}
+
+#[test]
+fn test_threshold_eddsa_shamir_identifies_cheating_parties() {
+    test_threshold_eddsa(7, 3, &[0, 2]);
+}

--- a/threshold-eddsa-babyjubjub/src/shamir/test.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/test.rs
@@ -74,14 +74,13 @@ pub(crate) fn test_threshold_eddsa_inner<R: Rng + CryptoRng>(
 
     // 3) Aggregator challenges used used parties
     let mut used_sigs = Vec::with_capacity(num_parties);
-    let mut lagrange_coefficients = Vec::with_capacity(num_parties);
 
     for server_idx in &used_parties {
         // we just use an option here in tests to be able to move out of the vector since the session is consumed
         let session = sessions[*server_idx as usize - 1]
             .take()
             .expect("have not used this session before");
-        let x_ = x_shares[*server_idx as usize - 1].clone();
+        let x_ = &x_shares[*server_idx as usize - 1];
         let lagrange = utils::single_lagrange_from_coeff(*server_idx, &used_parties);
         let proof = session.sign_round(
             session_id,
@@ -92,7 +91,6 @@ pub(crate) fn test_threshold_eddsa_inner<R: Rng + CryptoRng>(
             lagrange,
         );
         used_sigs.push(proof);
-        lagrange_coefficients.push(lagrange);
     }
 
     for &position in cheating_positions {
@@ -119,7 +117,6 @@ pub(crate) fn test_threshold_eddsa_inner<R: Rng + CryptoRng>(
         public_key,
         &used_public_key_shares,
         &used_commitments,
-        &lagrange_coefficients,
     );
 
     if cheating_positions.is_empty() {

--- a/threshold-eddsa-babyjubjub/src/shamir/test.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/test.rs
@@ -19,6 +19,7 @@ use uuid::Uuid;
 
 fn share<R: Rng>(
     secret: ScalarField,
+    public_key: &EdDSAPublicKey,
     num_shares: usize,
     degree: usize,
     rng: &mut R,
@@ -34,6 +35,7 @@ fn share<R: Rng>(
         shares.push(
             DLogShareShamir::new(
                 share,
+                public_key,
                 u16::try_from(i).expect("party ID fits"),
                 u16::try_from(num_shares).expect("party count fits"),
                 u16::try_from(degree + 1).expect("threshold fits"),
@@ -92,7 +94,7 @@ pub(crate) fn test_threshold_eddsa_inner<R: Rng + CryptoRng>(
             .expect("have not used this session before");
         let x_ = &x_shares[*server_idx as usize - 1];
         let proof = session
-            .sign_round(session_id, x_, message, public_key, challenge.clone())
+            .sign_round(session_id, x_, message, challenge.clone())
             .expect("valid signing package");
         used_sigs.push(proof);
     }
@@ -136,9 +138,8 @@ pub(crate) fn test_threshold_eddsa_inner<R: Rng + CryptoRng>(
         match result {
             Err(error) => assert_eq!(
                 error
-                    .downcast::<crate::MaliciousPartiesError>()
-                    .expect("malicious-party error")
-                    .into_inner(),
+                    .into_malicious_parties()
+                    .expect("the abort must attribute blame, not report bad input"),
                 expected,
             ),
             Ok(_) => panic!("cheating parties must be identified"),
@@ -152,18 +153,18 @@ fn test_threshold_eddsa(num_parties: usize, degree: usize, cheating_positions: &
 
     let message = BaseField::rand(&mut rng);
     let x = ScalarField::rand(&mut rng);
-    let x_shares = share(x, num_parties, degree, &mut rng);
+    let public_key = EdDSAPublicKey {
+        pk: (Affine::generator() * x).into_affine(),
+    };
+    let x_shares = share(x, &public_key, num_parties, degree, &mut rng);
 
-    // Create public keys
-    let public_key = (Affine::generator() * x).into_affine();
     let public_key_shares = x_shares
         .iter()
         .map(|x| Affine::generator() * x.value)
         .collect::<Vec<_>>();
     let public_key_ =
         utils::test_utils::reconstruct_random_pointshares(&public_key_shares, degree, &mut rng);
-    assert_eq!(public_key, public_key_);
-    let public_key = EdDSAPublicKey { pk: public_key };
+    assert_eq!(public_key.pk, public_key_);
 
     let public_key_shares = public_key_shares
         .iter()
@@ -221,30 +222,76 @@ fn signer_rejects_mismatched_identity_and_insufficient_sets() {
     let (session, commitment) = EdDSASessionShamir::pre_round(1, &mut rng).expect("valid party ID");
     let aggregate =
         EdDSACommitmentsShamir::pre_agg(&[commitment]).expect("valid single-party commitment set");
-    let other_party_share = DLogShareShamir::new(ScalarField::rand(&mut rng), 2, 2, 1)
+    let other_party_share = DLogShareShamir::new(ScalarField::rand(&mut rng), &public_key, 2, 2, 1)
         .expect("valid metadata for another party");
-    let Err(_) = session.sign_round(
-        Uuid::new_v4(),
-        &other_party_share,
-        message,
-        &public_key,
-        aggregate,
-    ) else {
+    let Err(_) =
+        session.sign_round(Uuid::new_v4(), &other_party_share, message, aggregate)
+    else {
         panic!("a nonce session must not sign for another key-share identity");
     };
 
     let (session, commitment) = EdDSASessionShamir::pre_round(1, &mut rng).expect("valid party ID");
     let aggregate =
         EdDSACommitmentsShamir::pre_agg(&[commitment]).expect("valid single-party commitment set");
-    let two_party_threshold_share = DLogShareShamir::new(ScalarField::rand(&mut rng), 1, 2, 2)
-        .expect("valid two-party threshold metadata");
-    let Err(_) = session.sign_round(
-        Uuid::new_v4(),
-        &two_party_threshold_share,
-        message,
-        &public_key,
-        aggregate,
-    ) else {
+    let two_party_threshold_share =
+        DLogShareShamir::new(ScalarField::rand(&mut rng), &public_key, 1, 2, 2)
+            .expect("valid two-party threshold metadata");
+    let Err(_) =
+        session.sign_round(Uuid::new_v4(), &two_party_threshold_share, message, aggregate)
+    else {
         panic!("a signer must reject a set below its bound threshold");
+    };
+}
+
+/// A key share is bound to the public key it belongs to, and deserialization enforces that binding
+/// and the committee metadata rather than deferring it to the signing path.
+#[test]
+fn key_share_deserialization_enforces_its_binding() {
+    let mut rng = rand::thread_rng();
+    let public_key = EdDSAPublicKey {
+        pk: (Affine::generator() * ScalarField::rand(&mut rng)).into_affine(),
+    };
+    let share = DLogShareShamir::new(ScalarField::rand(&mut rng), &public_key, 2, 3, 2)
+        .expect("valid share metadata");
+    let encoded = serde_json::to_value(&share).expect("share serializes");
+    let round_tripped = serde_json::from_value::<DLogShareShamir>(encoded.clone())
+        .expect("an honest share round-trips");
+    assert_eq!(round_tripped.public_key, public_key.pk);
+    assert_eq!(round_tripped.party_id(), 2);
+    assert_eq!(round_tripped.threshold(), 2);
+
+    let tamper = |field: &str, value: serde_json::Value| {
+        let mut encoded = encoded.clone();
+        encoded[field] = value;
+        serde_json::from_value::<DLogShareShamir>(encoded)
+    };
+    let Err(_) = tamper("party_id", 0.into()) else {
+        panic!("a zero party ID must be rejected");
+    };
+    let Err(_) = tamper("party_id", 4.into()) else {
+        panic!("a party ID outside the committee must be rejected");
+    };
+    let Err(_) = tamper("threshold", 0.into()) else {
+        panic!("a zero threshold must be rejected");
+    };
+    let Err(_) = tamper("threshold", 4.into()) else {
+        panic!("a threshold above the party count must be rejected");
+    };
+    // The neutral element (0, 1) is on the curve and in the prime-order subgroup, so the subgroup
+    // check alone accepts it; the explicit non-zero check is what rejects it.
+    let identity = serde_json::json!(["0", "1"]);
+    let Err(_) = tamper("public_key", identity) else {
+        panic!("an identity public key must be rejected");
+    };
+
+    // The share carries the key, so the signer cannot be pointed at a different one.
+    let Err(_) = DLogShareShamir::new(
+        ScalarField::rand(&mut rng),
+        &EdDSAPublicKey { pk: Affine::zero() },
+        1,
+        3,
+        2,
+    ) else {
+        panic!("a share must not be bound to a small-order public key");
     };
 }

--- a/threshold-eddsa-babyjubjub/src/shamir/test.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/test.rs
@@ -14,6 +14,7 @@ use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::UniformRand;
 use eddsa_babyjubjub::EdDSAPublicKey;
 use rand::{CryptoRng, Rng, seq::IteratorRandom};
+use std::collections::BTreeMap;
 use uuid::Uuid;
 
 fn share<R: Rng>(
@@ -30,7 +31,15 @@ fn share<R: Rng>(
     }
     for i in 1..=num_shares {
         let share = evaluate_poly(&coeffs, ScalarField::from(i as u64));
-        shares.push(DLogShareShamir(share));
+        shares.push(
+            DLogShareShamir::new(
+                share,
+                u16::try_from(i).expect("party ID fits"),
+                u16::try_from(num_shares).expect("party count fits"),
+                u16::try_from(degree + 1).expect("threshold fits"),
+            )
+            .expect("valid share metadata"),
+        );
     }
     shares
 }
@@ -57,8 +66,8 @@ pub(crate) fn test_threshold_eddsa_inner<R: Rng + CryptoRng>(
     // 1) Aggregator requests commitments from all servers
     let mut sessions = Vec::with_capacity(num_parties);
     let mut commitments = Vec::with_capacity(num_parties);
-    for _ in 0..num_parties {
-        let (session, comm) = EdDSASessionShamir::pre_round(rng);
+    for party_id in 1..=u16::try_from(num_parties).expect("party count fits") {
+        let (session, comm) = EdDSASessionShamir::pre_round(party_id, rng).expect("valid party ID");
         sessions.push(Some(session));
         commitments.push(comm);
     }
@@ -70,7 +79,8 @@ pub(crate) fn test_threshold_eddsa_inner<R: Rng + CryptoRng>(
         .map(|&i| commitments[i as usize - 1].clone())
         .collect::<Vec<_>>();
 
-    let challenge = EdDSACommitmentsShamir::pre_agg(&used_commitments, used_parties.clone());
+    let challenge = EdDSACommitmentsShamir::pre_agg(&used_commitments)
+        .expect("valid identity-bound commitments");
 
     // 3) Aggregator challenges used used parties
     let mut used_sigs = Vec::with_capacity(num_parties);
@@ -81,33 +91,27 @@ pub(crate) fn test_threshold_eddsa_inner<R: Rng + CryptoRng>(
             .take()
             .expect("have not used this session before");
         let x_ = &x_shares[*server_idx as usize - 1];
-        let lagrange = utils::single_lagrange_from_coeff(*server_idx, &used_parties);
-        let proof = session.sign_round(
-            session_id,
-            x_,
-            message,
-            public_key,
-            challenge.clone(),
-            lagrange,
-        );
+        let proof = session
+            .sign_round(session_id, x_, message, public_key, challenge.clone())
+            .expect("valid signing package");
         used_sigs.push(proof);
     }
 
     for &position in cheating_positions {
-        used_sigs[position].0.0 += ScalarField::from(1_u64);
+        used_sigs[position].0.1 += ScalarField::from(1_u64);
     }
 
     // 4) Aggregator combines received signature shares
     let used_public_key_shares = used_parties
         .iter()
-        .map(|&party_id| public_key_shares[usize::from(party_id) - 1])
-        .collect::<Vec<_>>();
+        .map(|&party_id| (party_id, public_key_shares[usize::from(party_id) - 1]))
+        .collect::<BTreeMap<_, _>>();
 
     // Without identifiable abort
-    let signature_noabort =
-        challenge
-            .clone()
-            .sign_agg(session_id, &used_sigs, message, public_key.clone());
+    let signature_noabort = challenge
+        .clone()
+        .sign_agg(session_id, &used_sigs, message, public_key.clone())
+        .expect("signature shares match the signing set");
 
     // With identifiable abort
     let result = challenge.sign_agg_with_identifiable_abort(
@@ -124,12 +128,19 @@ pub(crate) fn test_threshold_eddsa_inner<R: Rng + CryptoRng>(
         assert!(public_key.verify(message, &signature));
         assert!(public_key.verify(message, &signature_noabort));
     } else {
-        let expected = cheating_positions
+        let mut expected = cheating_positions
             .iter()
             .map(|&position| usize::from(used_parties[position]))
             .collect::<Vec<_>>();
+        expected.sort_unstable();
         match result {
-            Err(error) => assert_eq!(error.into_inner(), expected),
+            Err(error) => assert_eq!(
+                error
+                    .downcast::<crate::MaliciousPartiesError>()
+                    .expect("malicious-party error")
+                    .into_inner(),
+                expected,
+            ),
             Ok(_) => panic!("cheating parties must be identified"),
         }
         assert!(!public_key.verify(message, &signature_noabort));
@@ -147,7 +158,7 @@ fn test_threshold_eddsa(num_parties: usize, degree: usize, cheating_positions: &
     let public_key = (Affine::generator() * x).into_affine();
     let public_key_shares = x_shares
         .iter()
-        .map(|x| Affine::generator() * x.0)
+        .map(|x| Affine::generator() * x.value)
         .collect::<Vec<_>>();
     let public_key_ =
         utils::test_utils::reconstruct_random_pointshares(&public_key_shares, degree, &mut rng);
@@ -184,4 +195,56 @@ fn test_threshold_eddsa_shamir_31_15() {
 #[test]
 fn test_threshold_eddsa_shamir_identifies_cheating_parties() {
     test_threshold_eddsa(7, 3, &[0, 2]);
+}
+
+#[test]
+fn aggregate_commitment_deserialization_enforces_party_invariants() {
+    let mut rng = rand::thread_rng();
+    let (_, commitment) = EdDSASessionShamir::pre_round(1, &mut rng).expect("valid party ID");
+    let aggregate =
+        EdDSACommitmentsShamir::pre_agg(&[commitment]).expect("valid aggregate commitment");
+    let mut encoded = serde_json::to_value(aggregate).expect("serialize aggregate commitment");
+    encoded["contributing_parties"] = serde_json::json!([0]);
+    let Err(_) = serde_json::from_value::<EdDSACommitmentsShamir>(encoded) else {
+        panic!("non-canonical commitment parties must be rejected");
+    };
+}
+
+#[test]
+fn signer_rejects_mismatched_identity_and_insufficient_sets() {
+    let mut rng = rand::thread_rng();
+    let message = BaseField::rand(&mut rng);
+    let public_key = EdDSAPublicKey {
+        pk: (Affine::generator() * ScalarField::rand(&mut rng)).into_affine(),
+    };
+
+    let (session, commitment) = EdDSASessionShamir::pre_round(1, &mut rng).expect("valid party ID");
+    let aggregate =
+        EdDSACommitmentsShamir::pre_agg(&[commitment]).expect("valid single-party commitment set");
+    let other_party_share = DLogShareShamir::new(ScalarField::rand(&mut rng), 2, 2, 1)
+        .expect("valid metadata for another party");
+    let Err(_) = session.sign_round(
+        Uuid::new_v4(),
+        &other_party_share,
+        message,
+        &public_key,
+        aggregate,
+    ) else {
+        panic!("a nonce session must not sign for another key-share identity");
+    };
+
+    let (session, commitment) = EdDSASessionShamir::pre_round(1, &mut rng).expect("valid party ID");
+    let aggregate =
+        EdDSACommitmentsShamir::pre_agg(&[commitment]).expect("valid single-party commitment set");
+    let two_party_threshold_share = DLogShareShamir::new(ScalarField::rand(&mut rng), 1, 2, 2)
+        .expect("valid two-party threshold metadata");
+    let Err(_) = session.sign_round(
+        Uuid::new_v4(),
+        &two_party_threshold_share,
+        message,
+        &public_key,
+        aggregate,
+    ) else {
+        panic!("a signer must reject a set below its bound threshold");
+    };
 }

--- a/threshold-eddsa-babyjubjub/src/shamir/test.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/test.rs
@@ -224,9 +224,7 @@ fn signer_rejects_mismatched_identity_and_insufficient_sets() {
         EdDSACommitmentsShamir::pre_agg(&[commitment]).expect("valid single-party commitment set");
     let other_party_share = DLogShareShamir::new(ScalarField::rand(&mut rng), &public_key, 2, 2, 1)
         .expect("valid metadata for another party");
-    let Err(_) =
-        session.sign_round(Uuid::new_v4(), &other_party_share, message, aggregate)
-    else {
+    let Err(_) = session.sign_round(Uuid::new_v4(), &other_party_share, message, aggregate) else {
         panic!("a nonce session must not sign for another key-share identity");
     };
 
@@ -236,9 +234,12 @@ fn signer_rejects_mismatched_identity_and_insufficient_sets() {
     let two_party_threshold_share =
         DLogShareShamir::new(ScalarField::rand(&mut rng), &public_key, 1, 2, 2)
             .expect("valid two-party threshold metadata");
-    let Err(_) =
-        session.sign_round(Uuid::new_v4(), &two_party_threshold_share, message, aggregate)
-    else {
+    let Err(_) = session.sign_round(
+        Uuid::new_v4(),
+        &two_party_threshold_share,
+        message,
+        aggregate,
+    ) else {
         panic!("a signer must reject a set below its bound threshold");
     };
 }

--- a/threshold-eddsa-babyjubjub/src/shamir/utils.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/utils.rs
@@ -78,11 +78,17 @@ pub fn evaluate_poly<F: PrimeField>(poly: &[F], x: F) -> F {
     eval
 }
 
+/// Evaluates a committed polynomial in the exponent at a party index.
+///
+/// # Panics
+/// Panics if `party_idx` is zero or `coefficients` is empty. A zero index would return the
+/// commitment to the constant term, which in the reshare protocol is the sender's secret key
+/// share, so this must never be a silent no-op in release builds.
 pub fn evaluate_polynomial_in_exponent<C: CurveGroup>(
     coefficients: &[C::Affine],
     party_idx: u16,
 ) -> C {
-    debug_assert!(party_idx > 0, "party index must be non-zero");
+    assert!(party_idx > 0, "party index must be non-zero");
     // since the party index is non-zero, this is non zero
     let x = C::ScalarField::from(party_idx);
 
@@ -103,11 +109,18 @@ pub fn evaluate_polynomial_in_exponent<C: CurveGroup>(
     result
 }
 
+/// Checks a private polynomial evaluation against the public coefficient commitments.
+///
+/// A zero `party_idx` or an empty commitment vector is rejected rather than evaluated, so a
+/// malformed index can never make a share equal to the constant term verify.
 pub fn verify_polynomial_evaluation<C: CurveGroup>(
     commitments: &[C::Affine],
     party_idx: u16,
     share: &C::ScalarField,
 ) -> bool {
+    if party_idx == 0 || commitments.is_empty() {
+        return false;
+    }
     let result = evaluate_polynomial_in_exponent::<C>(commitments, party_idx);
     result == C::generator() * share
 }

--- a/threshold-eddsa-babyjubjub/src/shamir/utils.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/utils.rs
@@ -1,0 +1,152 @@
+//! Utilities for Lagrange interpolation and polynomial evaluation over finite fields.
+//!
+//! Provides functions to compute Lagrange coefficients, evaluate polynomials, and reconstruct secrets from shares.
+
+use ark_ff::PrimeField;
+
+/// Computes the Lagrange coefficients for the provided party indices.
+///
+/// # Arguments
+///
+/// * `coeffs` - Slice of party indices.
+///
+/// # Returns
+///
+/// Vector of Lagrange coefficients for each party.
+pub fn lagrange_from_coeff<F: PrimeField + From<T>, T: Copy + Eq>(coeffs: &[T]) -> Vec<F> {
+    let num = coeffs.len();
+    let mut res = Vec::with_capacity(num);
+    for i in coeffs {
+        res.push(single_lagrange_from_coeff(*i, coeffs));
+    }
+    res
+}
+
+/// Computes the Lagrange coefficient for a specific party identifier.
+///
+/// # Arguments
+///
+/// * `my_id` - Party identifier.
+/// * `coeffs` - Slice of party indices.
+///
+/// # Returns
+///
+/// The Lagrange coefficient for `my_id`.
+///
+/// # Panics
+/// Might panic if chosen `T` does not fit into `Primefield`.
+pub fn single_lagrange_from_coeff<F: PrimeField + From<T>, T: Copy + Eq>(
+    my_id: T,
+    coeffs: &[T],
+) -> F {
+    let mut num = F::one();
+    let mut den = F::one();
+    let i_ = F::from(my_id);
+    for j in coeffs {
+        if my_id != *j {
+            let j_ = F::from(*j);
+            num *= j_;
+            den *= j_ - i_;
+        }
+    }
+    num * den.inverse().expect("Has an inverse")
+}
+
+/// Evaluates a polynomial at the given point.
+///
+/// # Arguments
+///
+/// * `poly` - Coefficients of the polynomial, low to high degree.
+/// * `x` - The point at which to evaluate.
+///
+/// # Returns
+///
+/// The polynomial evaluated at `x`.
+///
+/// # Panics
+/// If the provided polynomial is empty.
+pub fn evaluate_poly<F: PrimeField>(poly: &[F], x: F) -> F {
+    assert!(!poly.is_empty(), "Poly must not be empty");
+    let mut iter = poly.iter().rev();
+    let mut eval = iter.next().expect("Checked that not empty").to_owned();
+    for coeff in iter {
+        eval *= x;
+        eval += coeff;
+    }
+    eval
+}
+
+/// Recovers the secret by combining shares with Lagrange coefficients.
+///
+/// # Arguments
+///
+/// * `shares` - The shares from different parties.
+/// * `lagrange` - Corresponding Lagrange coefficients.
+///
+/// # Returns
+///
+/// The reconstructed secret value.
+///
+/// # Panics
+/// If provided shares and lagrange coefficients are not same length
+pub fn reconstruct<F: PrimeField>(shares: &[F], lagrange: &[F]) -> F {
+    assert_eq!(
+        shares.len(),
+        lagrange.len(),
+        "Shares and lagrange coeffs must be same length"
+    );
+    let mut res = F::zero();
+    for (s, l) in shares.iter().zip(lagrange.iter()) {
+        res += *s * l;
+    }
+    res
+}
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use crate::shamir::utils::{lagrange_from_coeff, reconstruct};
+    use ark_ec::CurveGroup;
+    use ark_ff::PrimeField;
+    use rand::{Rng, seq::IteratorRandom as _};
+
+    /// Reconstructs a curve point from its Shamir shares and lagrange coefficients.
+    pub(crate) fn reconstruct_point<C: CurveGroup>(
+        shares: &[C::Affine],
+        lagrange: &[C::ScalarField],
+    ) -> C {
+        debug_assert_eq!(shares.len(), lagrange.len());
+        C::msm_unchecked(shares, lagrange)
+    }
+
+    pub(crate) fn reconstruct_random_shares<F: PrimeField, R: Rng>(
+        shares: &[F],
+        degree: usize,
+        rng: &mut R,
+    ) -> F {
+        let num_parties = shares.len();
+        let parties = (1..=num_parties as u64).choose_multiple(rng, degree + 1);
+        let shares = parties
+            .iter()
+            .map(|&i| shares[usize::try_from(i - 1).expect("Fits into usize")])
+            .collect::<Vec<_>>();
+        let lagrange = lagrange_from_coeff(&parties);
+        reconstruct(&shares, &lagrange)
+    }
+
+    pub(crate) fn reconstruct_random_pointshares<C: CurveGroup, R: Rng>(
+        shares: &[C],
+        degree: usize,
+        rng: &mut R,
+    ) -> C {
+        let num_parties = shares.len();
+        let parties = (1..=num_parties as u64).choose_multiple(rng, degree + 1);
+        // maybe sufficient to into_affine in the following map
+        let shares = parties
+            .iter()
+            .map(|&i| shares[usize::try_from(i - 1).expect("Fits into usize")])
+            .collect::<Vec<_>>();
+        let shares = C::batch_convert_to_mul_base(&shares);
+        let lagrange = lagrange_from_coeff(&parties);
+        reconstruct_point(&shares, &lagrange)
+    }
+}

--- a/threshold-eddsa-babyjubjub/src/shamir/utils.rs
+++ b/threshold-eddsa-babyjubjub/src/shamir/utils.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides functions to compute Lagrange coefficients, evaluate polynomials, and reconstruct secrets from shares.
 
+use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::PrimeField;
 
 /// Computes the Lagrange coefficients for the provided party indices.
@@ -13,6 +14,7 @@ use ark_ff::PrimeField;
 /// # Returns
 ///
 /// Vector of Lagrange coefficients for each party.
+#[cfg(test)]
 pub fn lagrange_from_coeff<F: PrimeField + From<T>, T: Copy + Eq>(coeffs: &[T]) -> Vec<F> {
     let num = coeffs.len();
     let mut res = Vec::with_capacity(num);
@@ -76,38 +78,72 @@ pub fn evaluate_poly<F: PrimeField>(poly: &[F], x: F) -> F {
     eval
 }
 
-/// Recovers the secret by combining shares with Lagrange coefficients.
-///
-/// # Arguments
-///
-/// * `shares` - The shares from different parties.
-/// * `lagrange` - Corresponding Lagrange coefficients.
-///
-/// # Returns
-///
-/// The reconstructed secret value.
-///
-/// # Panics
-/// If provided shares and lagrange coefficients are not same length
-pub fn reconstruct<F: PrimeField>(shares: &[F], lagrange: &[F]) -> F {
-    assert_eq!(
-        shares.len(),
-        lagrange.len(),
-        "Shares and lagrange coeffs must be same length"
-    );
-    let mut res = F::zero();
-    for (s, l) in shares.iter().zip(lagrange.iter()) {
-        res += *s * l;
+pub fn evaluate_polynomial_in_exponent<C: CurveGroup>(
+    coefficients: &[C::Affine],
+    party_idx: u16,
+) -> C {
+    debug_assert!(party_idx > 0, "party index must be non-zero");
+    // since the party index is non-zero, this is non zero
+    let x = C::ScalarField::from(party_idx);
+
+    assert!(!coefficients.is_empty(), "Poly must not be empty");
+    let mut iter = coefficients.iter().rev();
+    let mut result = iter
+        .next()
+        .expect("Checked that not empty")
+        .to_owned()
+        .into_group();
+
+    // evaluate the poly using Horner's algorithm
+    for coeff in iter {
+        result *= &x;
+        result += coeff;
     }
-    res
+
+    result
+}
+
+pub fn verify_polynomial_evaluation<C: CurveGroup>(
+    commitments: &[C::Affine],
+    party_idx: u16,
+    share: &C::ScalarField,
+) -> bool {
+    let result = evaluate_polynomial_in_exponent::<C>(commitments, party_idx);
+    result == C::generator() * share
 }
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use crate::shamir::utils::{lagrange_from_coeff, reconstruct};
+    use crate::shamir::utils::lagrange_from_coeff;
     use ark_ec::CurveGroup;
     use ark_ff::PrimeField;
     use rand::{Rng, seq::IteratorRandom as _};
+
+    /// Recovers the secret by combining shares with Lagrange coefficients.
+    ///
+    /// # Arguments
+    ///
+    /// * `shares` - The shares from different parties.
+    /// * `lagrange` - Corresponding Lagrange coefficients.
+    ///
+    /// # Returns
+    ///
+    /// The reconstructed secret value.
+    ///
+    /// # Panics
+    /// If provided shares and lagrange coefficients are not same length
+    pub fn reconstruct<F: PrimeField>(shares: &[F], lagrange: &[F]) -> F {
+        assert_eq!(
+            shares.len(),
+            lagrange.len(),
+            "Shares and lagrange coeffs must be same length"
+        );
+        let mut res = F::zero();
+        for (s, l) in shares.iter().zip(lagrange.iter()) {
+            res += *s * l;
+        }
+        res
+    }
 
     /// Reconstructs a curve point from its Shamir shares and lagrange coefficients.
     pub(crate) fn reconstruct_point<C: CurveGroup>(

--- a/threshold-eddsa-babyjubjub/src/signature.rs
+++ b/threshold-eddsa-babyjubjub/src/signature.rs
@@ -12,8 +12,8 @@ use serde::{Deserialize, Serialize};
 /// Individual party's proof share for the `EdDSA` protocol.
 /// Carries a response share for the signature.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(transparent)]
 pub(crate) struct EdDSASigShare(
-    // The share of the response s
+    pub(crate) u16,
+    // The share of the response s.
     #[serde(with = "ark_serde_compat::field")] pub(crate) ScalarField,
 );

--- a/threshold-eddsa-babyjubjub/src/signature.rs
+++ b/threshold-eddsa-babyjubjub/src/signature.rs
@@ -1,0 +1,19 @@
+//! Signature Shares for Threshold `EdDSA`
+//!
+//! This module defines the `EdDSASigShare` struct, a single party's share of the response `s` of
+//! the final `EdDSA` signature.
+//!
+//! The primitives defined here are agnostic to the underlying threshold sharing scheme and are used by both
+//! additive and Shamir variants, which are implemented in their respective submodules `additive` and `shamir`.
+
+use crate::ScalarField;
+use serde::{Deserialize, Serialize};
+
+/// Individual party's proof share for the `EdDSA` protocol.
+/// Carries a response share for the signature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct EdDSASigShare(
+    // The share of the response s
+    #[serde(with = "ark_serde_compat::field")] pub(crate) ScalarField,
+);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Introduces full threshold signing, distributed key generation, and resharing with secret shares and protocol-state handling; misconfigured networking or session IDs can break safety assumptions documented in the crate.
> 
> **Overview**
> Adds **`taceo-threshold-eddsa-babyjubjub`**, a new workspace crate for **t-of-n Shamir** threshold Baby Jubjub EdDSA (FROST3-style two-nonce preprocessing + signing), **PedPoP-style dealerless DKG** with an optional public blame round, and **resharing** that preserves the signing key while changing participants or thresholds. Final signatures are ordinary **`EdDSASignature`** values verified with the existing single-party API.
> 
> **`eddsa-babyjubjub`** exposes **`challenge_hash`** and **`convert_base_to_scalar`** so the threshold layer can build the same Fiat–Shamir challenge as single-party EdDSA. Workspace wiring adds **`itertools`**, **`uuid`**, and a path dependency on **`eddsa-babyjubjub`**.
> 
> Signing supports plain aggregation and **`sign_agg_with_identifiable_abort`** (malicious share IDs vs inconsistent aggregator input). DKG/reshare outputs include **`agreement_digest`** for cross-participant comparison—especially important after reshare when divergent sender sets can still reconstruct the same public key. An **`additive`** feature provides **n-of-n** additive sharing wrappers around shared commit/nonce/session primitives. Integrators must supply reliable broadcast, authentication, and coordinated timeouts; the crate documents these requirements but does not implement networking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1391076b880cff27187130442d68806d1390baac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->